### PR TITLE
Rate limit queries that require gateway access.  

### DIFF
--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -17,6 +17,12 @@ _LOGGER = logging.getLogger(__name__)
 GW_LOCK = asyncio.Lock()
 
 
+class RequestFailed(Exception):
+    """Exception when TTLock API returns an error."""
+
+    pass
+
+
 class TTLockAuthImplementation(
     AuthImplementation,
 ):
@@ -85,7 +91,7 @@ class TTLockApi:
 
         res = cast(dict, await resp.json())
         if res.get("errcode", 0) != 0:
-            raise RuntimeError("API returned: %s", res.get("errmsg", "Unknown error"))
+            raise RequestFailed(f"API returned: {res}")
 
         return cast(dict, await resp.json())
 

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -32,6 +32,7 @@ class State(Enum):
 
     locked = 0
     unlocked = 1
+    unknown = 2
 
 
 class Lock(BaseModel):
@@ -64,7 +65,7 @@ class Lock(BaseModel):
 class LockState(BaseModel):
     """Lock state."""
 
-    locked: State | None = Field(..., alias="state")
+    locked: State | None = Field(State.unknown, alias="state")
 
 
 class PassageModeConfig(BaseModel):


### PR DESCRIPTION
In future we may try to be a bit smarter about which lock is connected to which gateway and throttle per gateway, but since the TTLock API makes it clear that locks can move between gateways and that fetching this data is in itself a request to the gateway I don't think that will be particularly easy to get right.

Hopefully fixes #34 