### PR TITLE
ignore locks without gateway

### DIFF
--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -105,7 +105,7 @@ class TTLockApi:
     async def get_locks(self) -> list[int]:
         """Enumerate all locks in the account."""
         res = await self.get("lock/list", pageNo=1, pageSize=1000)
-        return [lock["lockId"] for lock in res["list"]]
+        return [lock["lockId"] for lock in res["list"] if lock["hasGateway"] != 0]
 
     async def get_lock(self, lock_id: int) -> Lock:
         """Get a lock by ID."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 pytest-homeassistant-custom-component
-hass_nabucasa # cloud component
+# cloud component
+hass_nabucasa
+webrtcvad
+hassil
+home-assistant-intents
+mutagen
 aiohttp_cors # http component
 dateparser # tests


### PR DESCRIPTION
It's unclear in the ttlock docs how wifi locks report themselves here and I don't have any to personally test, so this might need further work.