### PR TITLE
skip processing webhook if lock isnt set up

### DIFF
--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -162,6 +162,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         if not event.success:
             return
 
+        if not self.data:
+            return
+
         new_data = deepcopy(self.data)
         new_data.battery_level = event.battery_level
 


### PR DESCRIPTION
In #59 we see an error where having lots of locks takes a long time to setup, but web hooks start arriving before the locks are initialized. This should skip processing the event in those cases.