### PR TITLE
Stop using async_register in service setup

### DIFF
--- a/custom_components/ttlock/services.py
+++ b/custom_components/ttlock/services.py
@@ -74,7 +74,7 @@ class Services:
             ),
         )
 
-        self.hass.services.async_register(
+        self.hass.services.register(
             DOMAIN,
             SVC_CLEANUP_PASSCODES,
             self.handle_cleanup_passcodes,


### PR DESCRIPTION
All the calls used `register` except this one, which wasn't being awaited either, so this likely also means `cleanup_passcodes` didn't actually work.

Fixes #107