### PR TITLE
Expand ruff lint rules to match Home Assistant config

### DIFF
--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -33,8 +33,6 @@ GW_LOCK = asyncio.Lock()
 class RequestFailed(Exception):
     """Exception when TTLock API returns an error."""
 
-    pass
-
 
 class TTLockAuthImplementation(
     AuthImplementation,
@@ -329,7 +327,7 @@ class TTLockApi:
 
         if "errcode" in res and res["errcode"] != 0:
             _LOGGER.error(
-                "Failed to update autolock",
+                "Failed to update autolock for %s: %s",
                 lock_id,
                 res["errmsg"],
             )
@@ -351,7 +349,7 @@ class TTLockApi:
 
         if "errcode" in res and res["errcode"] != 0:
             _LOGGER.error(
-                "Failed to update sound setting",
+                "Failed to update sound setting for %s: %s",
                 lock_id,
                 res["errmsg"],
             )

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import contextmanager
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import logging
 from typing import TypeGuard
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .api import TTLockApi
 from .const import DOMAIN, SIGNAL_NEW_DATA, TT_LOCKS
@@ -48,7 +48,7 @@ class LockState:
     battery_level: int | None = None
     hardware_version: str | None = None
     firmware_version: str | None = None
-    features: Features = Features.from_feature_value(None)
+    features: Features = field(default_factory=lambda: Features(0))
     locked: bool | None = None
     action_pending: bool = False
     last_user: str | None = None
@@ -58,8 +58,10 @@ class LockState:
     auto_lock_seconds: int | None = None
     passage_mode_config: PassageModeConfig | None = None
 
-    def passage_mode_active(self, current_date: datetime = dt.now()) -> bool:
+    def passage_mode_active(self, current_date: datetime | None = None) -> bool:
         """Check if passage mode is currently active."""
+        if current_date is None:
+            current_date = dt_util.now()
         if self.passage_mode_config and self.passage_mode_config.enabled:
             current_day = current_date.isoweekday()
 
@@ -175,10 +177,10 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
                 # only fetch sensor metadata once a day
                 if (
                     new_data.sensor.last_fetched is None
-                    or new_data.sensor.last_fetched < dt.now() - timedelta(days=1)
+                    or new_data.sensor.last_fetched < dt_util.now() - timedelta(days=1)
                 ):
                     sensor = await self.api.get_sensor(self.lock_id)
-                    new_data.sensor.last_fetched = dt.now()
+                    new_data.sensor.last_fetched = dt_util.now()
                     if sensor:
                         new_data.sensor.battery = sensor.battery_level
             else:
@@ -190,8 +192,8 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
                     new_data.locked = state.locked == State.locked
                     if sensor_present(new_data.sensor):
                         new_data.sensor.opened = state.opened == SensorState.opened
-                except Exception:
-                    pass
+                except Exception:  # noqa: BLE001 - lock/sensor state fetch is best-effort
+                    _LOGGER.debug("Failed to fetch lock state", exc_info=True)
 
             new_data.auto_lock_seconds = details.autoLockTime
             new_data.lock_sound = bool(details.lockSound)
@@ -199,10 +201,10 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             new_data.passage_mode_config = await self.api.get_lock_passage_mode_config(
                 self.lock_id
             )
-
-            return new_data
         except Exception as err:
             raise UpdateFailed(err) from err
+        else:
+            return new_data
 
     @callback
     def _process_webhook_data(self, event: WebhookEvent):

--- a/custom_components/ttlock/diagnostics.py
+++ b/custom_components/ttlock/diagnostics.py
@@ -43,7 +43,7 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
 
-    diagnostics_data = async_redact_data(
+    return async_redact_data(
         {
             "config_entry": config_entry.as_dict(),
             "locks": [
@@ -53,5 +53,3 @@ async def async_get_config_entry_diagnostics(
         },
         TO_REDACT,
     )
-
-    return diagnostics_data

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -1,13 +1,13 @@
 """Models for parsing the TTLock API data."""
 
-from collections import namedtuple
 from datetime import datetime
 from enum import Enum, IntEnum, IntFlag, auto
+from typing import ClassVar, NamedTuple
 
 from pydantic import BaseModel, Field, GetCoreSchemaHandler, field_validator
 from pydantic_core import core_schema
 
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 
 class EpochMs(datetime):
@@ -21,7 +21,7 @@ class EpochMs(datetime):
     @classmethod
     def validate(cls, v):
         """Use homeassistant time helpers to parse epoch."""
-        return dt.as_local(dt.utc_from_timestamp(v / 1000))
+        return dt_util.as_local(dt_util.utc_from_timestamp(v / 1000))
 
 
 class OnOff(Enum):
@@ -180,7 +180,7 @@ class Passcode(BaseModel):
             PasscodeType.sundays,
         )
         if self.type in time_bounded_types and self.end_date:
-            return self.end_date < dt.now()
+            return self.end_date < dt_util.now()
 
         # Assume not expired for other types
         return False
@@ -285,7 +285,11 @@ class Action(Enum):
     close = auto()
 
 
-EventDescription = namedtuple("EventDescription", ["action", "description"])
+class EventDescription(NamedTuple):
+    """Human-readable description of a lock event."""
+
+    action: Action
+    description: str
 
 
 class Event:
@@ -295,7 +299,7 @@ class Event:
         """Initialize from int event id."""
         self._value_ = event_id
 
-    EVENTS: dict[int, EventDescription] = {
+    EVENTS: ClassVar[dict[int, EventDescription]] = {
         1: EventDescription(Action.unlock, "unlock by app"),
         4: EventDescription(Action.unlock, "unlock by passcode"),
         7: EventDescription(Action.unlock, "unlock by IC card"),
@@ -403,7 +407,7 @@ class WebhookEvent(BaseModel):
         """The end state of the lock after this event."""
         if self.success and self.event.action == Action.lock:
             return LockState(state=State.locked)
-        elif self.success and self.event.action == Action.unlock:
+        if self.success and self.event.action == Action.unlock:
             return LockState(state=State.unlocked)
         return LockState(state=None)
 
@@ -412,7 +416,7 @@ class WebhookEvent(BaseModel):
         """The end state of the sensor after this event."""
         if self.success and self.event.action == Action.close:
             return LockState(state=State.locked, sensorState=SensorState.closed)
-        elif self.success and self.event.action == Action.open:
+        if self.success and self.event.action == Action.open:
             return LockState(sensorState=SensorState.opened)
         return LockState(sensorState=None)
 

--- a/custom_components/ttlock/services.py
+++ b/custom_components/ttlock/services.py
@@ -265,7 +265,7 @@ class Services:
             weekDays=days,
         )
 
-        for _entity_id, coordinator in self._get_coordinators(call).items():
+        for coordinator in self._get_coordinators(call).values():
             if await coordinator.api.set_passage_mode(coordinator.lock_id, config):
                 coordinator.data.passage_mode_config = config
                 coordinator.async_update_listeners()
@@ -294,7 +294,7 @@ class Services:
             endDate=end_time,
         )
 
-        for _entity_id, coordinator in self._get_coordinators(call).items():
+        for coordinator in self._get_coordinators(call).values():
             await coordinator.api.add_passcode(coordinator.lock_id, config)
 
     async def handle_modify_passcode(self, call: ServiceCall):
@@ -323,7 +323,7 @@ class Services:
 
         passcode_id = call.data.get("passcode_id")
 
-        for _entity_id, coordinator in self._get_coordinators(call).items():
+        for coordinator in self._get_coordinators(call).values():
             await coordinator.api.modify_passcode(
                 coordinator.lock_id, passcode_id, config
             )
@@ -333,7 +333,7 @@ class Services:
 
         passcode_id = call.data.get("passcode_id")
 
-        for _entity_id, coordinator in self._get_coordinators(call).items():
+        for coordinator in self._get_coordinators(call).values():
             await coordinator.api.delete_passcode(coordinator.lock_id, passcode_id)
 
     async def handle_cleanup_passcodes(self, call: ServiceCall) -> ServiceResponse:
@@ -406,7 +406,7 @@ class Services:
 
     async def handle_update_state(self, call: ServiceCall):
         """Refresh the lock state by calling the coordinator's refresh method."""
-        for _entity_id, coordinator in self._get_coordinators(call).items():
+        for coordinator in self._get_coordinators(call).values():
             # Set the locked state to none to force the API call.
             coordinator.data.locked = None
             await coordinator.async_refresh()

--- a/custom_components/ttlock/webhook.py
+++ b/custom_components/ttlock/webhook.py
@@ -49,8 +49,9 @@ class WebhookHandler:
 
     async def try_generate_cloudhook(self) -> str | None:
         """Create a cloudhook if possible."""
-        # separate function so we can mock
-        from homeassistant.components import cloud
+        # deferred: cloud pulls in optional heavy dependencies we don't want to
+        # require at module import time, and this also lets tests mock it easily
+        from homeassistant.components import cloud  # noqa: PLC0415
 
         if cloud.async_active_subscription(self.hass):
             try:
@@ -67,10 +68,7 @@ class WebhookHandler:
             return self.entry.data[CONF_WEBHOOK_URL]
         if cloudhook := await self.try_generate_cloudhook():
             return cloudhook
-        else:
-            return webhook.async_generate_url(
-                self.hass, self.entry.data[CONF_WEBHOOK_ID]
-            )
+        return webhook.async_generate_url(self.hass, self.entry.data[CONF_WEBHOOK_ID])
 
     async def register_webhook(self, event: Event | None = None) -> None:
         """Set up a webhook to receive pushed data."""
@@ -135,8 +133,8 @@ class WebhookHandler:
                         success = True
             else:
                 _LOGGER.debug("handle_webhook, empty payload: %s", await request.text())
-        except ValueError as ex:
-            _LOGGER.exception("Exception parsing webhook data: %s", ex)
+        except ValueError:
+            _LOGGER.exception("Exception parsing webhook data")
             return
 
         if success and CONF_WEBHOOK_STATUS not in self.entry.data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,42 +14,156 @@ asyncio_default_fixture_loop_scope = "function"
 filterwarnings = []
 
 [tool.ruff]
+# Based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 target-version = "py313"
 
 [tool.ruff.lint]
 select = [
-    "B007", # Loop control variable {name} not used within loop body
-    "B014", # Exception handler with duplicate exception
-    "C",  # complexity
-    "D",  # docstrings
-    "E",  # pycodestyle
-    "F",  # pyflakes/autoflake
-    "I",  # isort
-    "PGH004",  # Use specific rule codes when using noqa
-    "PLC0414", # Useless import alias. Import alias does not rename original package.
-    "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
-    "SIM117", # Merge with-statements that use the same scope
-    "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
-    "SIM201", # Use {left} != {right} instead of not {left} == {right}
-    "SIM212", # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
-    "SIM300", # Yoda conditions. Use 'age == 42' instead of '42 == age'.
-    "SIM401", # Use get from dict with default instead of an if block
-    "T20",  # flake8-print
-    "TRY004", # Prefer TypeError exception for invalid type
-    "RUF006", # Store a reference to the return value of asyncio.create_task
-    "UP",  # pyupgrade
-    "W",  # pycodestyle
+    "A001",   # Variable {name} is shadowing a Python builtin
+    "ASYNC",  # flake8-async
+    "B002",   # Python does not support the unary prefix increment
+    "B005",   # Using .strip() with multi-character strings is misleading
+    "B007",   # Loop control variable {name} not used within loop body
+    "B009",   # Do not call getattr with a constant attribute value. It is not any safer than normal property access.
+    "B014",   # Exception handler with duplicate exception
+    "B015",   # Pointless comparison. Did you mean to assign a value? Otherwise, prepend assert or remove it.
+    "B017",   # pytest.raises(BaseException) should be considered evil
+    "B018",   # Found useless attribute access. Either assign it to a variable or remove it.
+    "B023",   # Function definition does not bind loop variable {name}
+    "B024",   # `{name}` is an abstract base class, but it has no abstract methods or properties
+    "B025",   # try-except* block with duplicate exception {name}
+    "B026",   # Star-arg unpacking after a keyword argument is strongly discouraged
+    "B032",   # Possible unintentional type annotation (using :). Did you mean to assign (using =)?
+    "B035",   # Dictionary comprehension uses static key
+    "B904",   # Use raise from to specify exception cause
+    "B905",   # zip() without an explicit strict= parameter
+    "BLE",    # flake8-blind-except
+    "C",      # complexity
+    "COM818", # Trailing comma on bare tuple prohibited
+    "D",      # docstrings
+    "DTZ003", # Use datetime.now(tz=) instead of datetime.utcnow()
+    "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
+    "E",      # pycodestyle
+    "F",      # pyflakes/autoflake
+    "FLY",    # flynt
+    "FURB",   # refurb
+    "G",      # flake8-logging-format
+    "I",      # isort
+    "INP",    # flake8-no-pep420
+    "ISC",    # flake8-implicit-str-concat
+    "ICN001", # import conventions; {name} should be imported as {asname}
+    "LOG",    # flake8-logging
+    "N804",   # First argument of a class method should be named cls
+    "N805",   # First argument of a method should be named self
+    "N815",   # Variable {name} in class scope should not be mixedCase
+    "PERF",   # Perflint
+    "PGH",    # pygrep-hooks
+    "PIE",    # flake8-pie
+    "PL",     # pylint
+    "PT",     # flake8-pytest-style
+    "PTH",    # flake8-pathlib
+    "PYI",    # flake8-pyi
+    "RET",    # flake8-return
+    "RSE",    # flake8-raise
+    "RUF",    # ruff-specific rules
+    "S102",   # Use of exec detected
+    "S103",   # bad-file-permissions
+    "S108",   # hardcoded-temp-file
+    "S306",   # suspicious-mktemp-usage
+    "S307",   # suspicious-eval-usage
+    "S313",   # suspicious-xmlc-element-tree-usage
+    "S314",   # suspicious-xml-element-tree-usage
+    "S315",   # suspicious-xml-expat-reader-usage
+    "S316",   # suspicious-xml-expat-builder-usage
+    "S317",   # suspicious-xml-sax-usage
+    "S318",   # suspicious-xml-mini-dom-usage
+    "S319",   # suspicious-xml-pull-dom-usage
+    "S601",   # paramiko-call
+    "S602",   # subprocess-popen-with-shell-equals-true
+    "S604",   # call-with-shell-equals-true
+    "S608",   # hardcoded-sql-expression
+    "S609",   # unix-command-wildcard-injection
+    "SIM",    # flake8-simplify
+    "SLF",    # flake8-self
+    "SLOT",   # flake8-slots
+    "T100",   # Trace found: {name} used
+    "T20",    # flake8-print
+    "TC",     # flake8-type-checking
+    "TID",    # Tidy imports
+    "TRY",    # tryceratops
+    "UP",     # pyupgrade
+    "W",      # pycodestyle
 ]
 
 ignore = [
-    "D202",  # No blank lines allowed after function docstring
-    "D203",  # 1 blank line required before class docstring
-    "D213",  # Multi-line docstring summary should start at the second line
-    "D406",  # Section name should end with a newline
-    "D407",  # Section name underlining
-    "E501",  # line too long
-    "E731",  # do not assign a lambda expression, use a def
+    "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
+    "ASYNC109", # Async function definition with a `timeout` parameter Use `asyncio.timeout` instead
+    "ASYNC110", # Use `asyncio.Event` instead of awaiting `asyncio.sleep` in a `while` loop
+    "ASYNC240", # Use an async function for entering the file system
+    "D202",     # No blank lines allowed after function docstring
+    "D203",     # 1 blank line required before class docstring
+    "D213",     # Multi-line docstring summary should start at the second line
+    "D406",     # Section name should end with a newline
+    "D407",     # Section name underlining
+    "D417",     # Missing argument descriptions in docstring - allows documenting only non-obvious parameters
+    "E501",     # line too long
+    "E731",     # do not assign a lambda expression, use a def
+
+    "PLC1901", # {existing} can be simplified to {replacement} as an empty string is falsey; too many false positives
+    "PLR0911", # Too many return statements ({returns} > {max_returns})
+    "PLR0912", # Too many branches ({branches} > {max_branches})
+    "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+    "PLR0915", # Too many statements ({statements} > {max_statements})
+    "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
+    "PLW0108", # Unnecessary lambda wrapping a function call; can often be replaced by the function itself
+    "PLW1641", # __eq__ without __hash__
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "PT011",   # pytest.raises({exception}) is too broad, set the `match` parameter or use a more specific exception
+    "PT018",   # Assertion should be broken down into multiple parts
+    "RUF001",  # String contains ambiguous unicode character.
+    "RUF002",  # Docstring contains ambiguous unicode character.
+    "RUF003",  # Comment contains ambiguous unicode character.
+    "RUF015",  # Prefer next(...) over single element slice
+    "SIM102",  # Use a single if statement instead of nested if statements
+    "SIM103",  # Return the condition {condition} directly
+    "SIM108",  # Use ternary operator {contents} instead of if-else-block
+    "SIM115",  # Use context handler for opening files
+
+    # Moving imports into type-checking blocks can mess with pytest.patch()
+    "TC001", # Move application import {} into a type-checking block
+    "TC002", # Move third-party import {} into a type-checking block
+    "TC003", # Move standard library import {} into a type-checking block
+    # Quotes for typing.cast generally not necessary, only for performance critical paths
+    "TC006", # Add quotes to type expression in typing.cast()
+
+    "TRY003", # Avoid specifying long messages outside the exception class
+    "TRY400", # Use `logging.exception` instead of `logging.error`
+
+    "UP046", # Non PEP 695 generic class
+    "UP047", # Non PEP 696 generic function
+    "UP049", # Avoid private type parameter names
+
+    # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D212",
+    "D300",
+    "Q",
+    "COM812",
+    "COM819",
+    "ISC001",
+
+    # Disabled because ruff does not understand type of __all__ generated by a function
+    "PLE0605",
+
+    "FURB116",
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 voluptuous = "vol"
@@ -58,9 +172,15 @@ voluptuous = "vol"
 "homeassistant.helpers.device_registry" = "dr"
 "homeassistant.helpers.entity_registry" = "er"
 "homeassistant.helpers.issue_registry" = "ir"
+"homeassistant.util.dt" = "dt_util"
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
+mark-parentheses = false
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"async_timeout".msg = "use asyncio.timeout instead"
+"pytz".msg = "use zoneinfo instead"
 
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = true
@@ -71,6 +191,12 @@ max-complexity = 25
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
     "D",  # docstrings
+]
+"tests/test_coordinator.py" = [
+    "SLF001",  # exercises LockUpdateCoordinator._process_webhook_data directly
+]
+"custom_components/ttlock/models.py" = [
+    "N815",  # fields mirror the TTLock API's camelCase wire format on purpose
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable loading custom integrations in all tests."""
-    yield
+    return enable_custom_integrations
 
 
 # persistent_notification doesn't exist during tests, patch it so we don't get stuck
@@ -59,7 +59,7 @@ def skip_notifications_fixture():
 @pytest.fixture
 def config_entry():
     """Mock a config entry."""
-    mock_entry = MockConfigEntry(
+    return MockConfigEntry(
         domain=DOMAIN,
         data={
             "auth_implementation": "mocked",
@@ -73,7 +73,6 @@ def config_entry():
             },
         },
     )
-    return mock_entry
 
 
 @pytest.fixture
@@ -117,7 +116,7 @@ class MockApiData(NamedTuple):
     state: LockState
     sensor: Sensor | None = None
     passage_mode: PassageModeConfig | None = None
-    records: list[LockRecord] = []
+    records: tuple[LockRecord, ...] = ()
 
 
 @pytest.fixture

--- a/tests/const.py
+++ b/tests/const.py
@@ -44,7 +44,7 @@ BASIC_LOCK_DETAILS = {
     "sensitivity": -1,
 }
 LOCK_DETAILS_WITH_SENSOR = {
-    **BASIC_LOCK_DETAILS,  # type: ignore
+    **BASIC_LOCK_DETAILS,
     "featureValue": "F44354CF5F3",
 }
 
@@ -86,28 +86,28 @@ _WEBHOOK_BASE = {
 }
 
 WEBHOOK_LOCK_10AM_UTC = {
-    **_WEBHOOK_BASE,  # type: ignore
+    **_WEBHOOK_BASE,
     "recordType": 47,
     "username": "test",
     "success": 1,
 }
 
 WEBHOOK_UNLOCK_10AM_UTC = {
-    **_WEBHOOK_BASE,  # type: ignore
+    **_WEBHOOK_BASE,
     "recordType": 7,
     "username": "test",
     "success": 1,
 }
 
 WEBHOOK_SENSOR_OPEN = {
-    **_WEBHOOK_BASE,  # type: ignore
+    **_WEBHOOK_BASE,
     "recordType": 31,
     "username": "test",
     "success": 1,
 }
 
 WEBHOOK_SENSOR_CLOSE = {
-    **_WEBHOOK_BASE,  # type: ignore
+    **_WEBHOOK_BASE,
     "recordType": 30,
     "username": "test",
     "success": 1,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,7 +8,7 @@ import pytest
 
 from custom_components.ttlock.coordinator import LockState, LockUpdateCoordinator
 from custom_components.ttlock.models import PassageModeConfig, WebhookEvent
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import (
     BASIC_LOCK_DETAILS,
@@ -143,7 +143,7 @@ class TestLockUpdateCoordinator:
 
             assert coordinator.data.sensor.opened is False
             assert coordinator.data.sensor.battery == 85
-            assert coordinator.data.sensor.last_fetched > dt.now() - timedelta(
+            assert coordinator.data.sensor.last_fetched > dt_util.now() - timedelta(
                 seconds=3
             )
 
@@ -154,7 +154,7 @@ class TestLockUpdateCoordinator:
             await coordinator.async_refresh()
 
             assert coordinator.data.sensor.present is False
-            assert coordinator.data.sensor.last_fetched > dt.now() - timedelta(
+            assert coordinator.data.sensor.last_fetched > dt_util.now() - timedelta(
                 seconds=3
             )
 
@@ -237,7 +237,7 @@ class TestLockUpdateCoordinator:
 
             coordinator.data.locked = True
             coordinator.data.auto_lock_seconds = -1
-            coordinator.data.sensor.opened is False
+            coordinator.data.sensor.opened = False
 
             event = WebhookEvent.model_validate(WEBHOOK_SENSOR_OPEN)
             coordinator._process_webhook_data(event)
@@ -253,7 +253,7 @@ class TestLockUpdateCoordinator:
 
             coordinator.data.locked = False
             coordinator.data.auto_lock_seconds = -1
-            coordinator.data.sensor.opened is True
+            coordinator.data.sensor.opened = True
 
             event = WebhookEvent.model_validate(WEBHOOK_SENSOR_CLOSE)
             coordinator._process_webhook_data(event)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,12 +20,12 @@ class TestEpochMs:
     @pytest.mark.parametrize(
         ("epoch", "tz", "day", "hour"),
         [
-            [1675400802000, "Europe/Amsterdam", 5, 6],
-            [1675400802000, "Pacific/Auckland", 5, 18],
-            [1675400802000, "America/Los_Angeles", 4, 21],
-            [1682244497000, "Europe/Amsterdam", 7, 12],
-            [1682244497000, "Pacific/Auckland", 7, 22],
-            [1682244497000, "America/Los_Angeles", 7, 3],
+            (1675400802000, "Europe/Amsterdam", 5, 6),
+            (1675400802000, "Pacific/Auckland", 5, 18),
+            (1675400802000, "America/Los_Angeles", 4, 21),
+            (1682244497000, "Europe/Amsterdam", 7, 12),
+            (1682244497000, "Pacific/Auckland", 7, 22),
+            (1682244497000, "America/Los_Angeles", 7, 3),
         ],
     )
     async def test_with_tz(self, hass, epoch, tz, day, hour):
@@ -67,14 +67,14 @@ class TestPassageModeConfig:
 
 
 class TestFeatures:
-    @pytest.fixture()
+    @pytest.fixture
     def features(self, feature_value):
         return Features.from_feature_value(feature_value)
 
     @pytest.mark.parametrize(
-        ["feature_value", "expected"],
-        (
-            [
+        ("feature_value", "expected"),
+        [
+            (
                 "10C2F44754CF5F7",
                 (
                     Features.lock_remotely,
@@ -83,16 +83,16 @@ class TestFeatures:
                     Features.wifi,
                     Features.door_sensor,
                 ),
-            ],
-            [
+            ),
+            (
                 "F44354CD5F3",
                 (
                     Features.lock_remotely,
                     Features.unlock_via_gateway,
                     Features.passage_mode,
                 ),
-            ],
-        ),
+            ),
+        ],
     )
     def test_flags(self, features: Features, expected):
         for feature in Features:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -26,7 +26,7 @@ from custom_components.ttlock.models import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 
 @pytest.fixture
@@ -92,8 +92,8 @@ class Test_list_passcodes:
         coordinator = await component_setup()
         entity_id = coordinator.entities[0].entity_id
 
-        start_time = dt.now() - timedelta(days=1)
-        end_time = dt.now() + timedelta(weeks=2)
+        start_time = dt_util.now() - timedelta(days=1)
+        end_time = dt_util.now() + timedelta(weeks=2)
         passcode = Passcode(
             keyboardPwdId=123,
             keyboardPwdType=PasscodeType.temporary,
@@ -175,8 +175,8 @@ class Test_list_records:
             success=False,
             username="test",
             keyboardPwd="123456",
-            lockDate=int(dt.now().timestamp() * 1000),
-            serverDate=int(dt.now().timestamp() * 1000),
+            lockDate=int(dt_util.now().timestamp() * 1000),
+            serverDate=int(dt_util.now().timestamp() * 1000),
         )
 
         with patch(
@@ -244,8 +244,8 @@ class Test_list_records:
         coordinator = await component_setup()
         entity_id = coordinator.entities[0].entity_id
 
-        start_time = dt.now() - timedelta(days=1)
-        end_time = dt.now()
+        start_time = dt_util.now() - timedelta(days=1)
+        end_time = dt_util.now()
 
         with patch(
             "custom_components.ttlock.api.TTLockApi.get_lock_records",
@@ -279,8 +279,8 @@ class Test_list_records:
         coordinator = await component_setup()
         entity_id = coordinator.entities[0].entity_id
 
-        start_time = dt.now() - timedelta(days=1)
-        end_time = dt.now()
+        start_time = dt_util.now() - timedelta(days=1)
+        end_time = dt_util.now()
 
         with patch(
             "custom_components.ttlock.api.TTLockApi.get_lock_records",
@@ -320,8 +320,8 @@ class Test_create_passcode:
         attrs = {
             "passcode_name": "Test User",
             "passcode": "1234",
-            "start_time": dt.now() - timedelta(days=1),
-            "end_time": dt.now() + timedelta(weeks=2),
+            "start_time": dt_util.now() - timedelta(days=1),
+            "end_time": dt_util.now() + timedelta(weeks=2),
         }
         with patch(
             "custom_components.ttlock.api.TTLockApi.add_passcode", return_value=True
@@ -358,8 +358,8 @@ class Test_create_passcode:
         attrs = {
             "passcode_name": "Test User",
             "passcode": "1234",
-            "start_time": dt.now() - timedelta(days=1),
-            "end_time": dt.now() + timedelta(weeks=2),
+            "start_time": dt_util.now() - timedelta(days=1),
+            "end_time": dt_util.now() + timedelta(weeks=2),
         }
         with patch(
             "custom_components.ttlock.api.TTLockApi.add_passcode", return_value=False
@@ -423,7 +423,7 @@ class Test_create_passcode:
                     ATTR_ENTITY_ID: [single_lock_entity_id],
                     "passcode_name": "Test",
                     "passcode": "1234",
-                    "start_time": dt.now(),
+                    "start_time": dt_util.now(),
                 },
                 blocking=True,
             )
@@ -441,7 +441,7 @@ class Test_create_passcode:
                     ATTR_ENTITY_ID: [single_lock_entity_id],
                     "passcode_name": "Test",
                     "passcode": "1234",
-                    "end_time": dt.now(),
+                    "end_time": dt_util.now(),
                 },
                 blocking=True,
             )
@@ -460,8 +460,8 @@ class Test_modify_passcode:
             "passcode_id": 123,
             "passcode_name": "Updated User",
             "passcode": "5678",
-            "start_time": dt.now() - timedelta(days=1),
-            "end_time": dt.now() + timedelta(weeks=2),
+            "start_time": dt_util.now() - timedelta(days=1),
+            "end_time": dt_util.now() + timedelta(weeks=2),
         }
         with patch(
             "custom_components.ttlock.api.TTLockApi.modify_passcode", return_value=True
@@ -500,8 +500,8 @@ class Test_modify_passcode:
             "passcode_id": 123,
             "passcode_name": "Updated User",
             "passcode": "5678",
-            "start_time": dt.now() - timedelta(days=1),
-            "end_time": dt.now() + timedelta(weeks=2),
+            "start_time": dt_util.now() - timedelta(days=1),
+            "end_time": dt_util.now() + timedelta(weeks=2),
         }
         with patch(
             "custom_components.ttlock.api.TTLockApi.modify_passcode", return_value=False
@@ -528,8 +528,8 @@ class Test_modify_passcode:
             "passcode_id": 123,
             "passcode_name": "Updated User",
             "passcode": "5678",
-            "start_time": dt.now() - timedelta(days=1),
-            "end_time": dt.now() + timedelta(weeks=2),
+            "start_time": dt_util.now() - timedelta(days=1),
+            "end_time": dt_util.now() + timedelta(weeks=2),
         }
         with patch(
             "custom_components.ttlock.api.TTLockApi.modify_passcode", return_value=True
@@ -597,7 +597,7 @@ class Test_modify_passcode:
                     "passcode_id": 123,
                     "passcode_name": "Test",
                     "passcode": "1234",
-                    "start_time": dt.now(),
+                    "start_time": dt_util.now(),
                 },
                 blocking=True,
             )
@@ -616,7 +616,7 @@ class Test_modify_passcode:
                     "passcode_id": 123,
                     "passcode_name": "Test",
                     "passcode": "1234",
-                    "end_time": dt.now(),
+                    "end_time": dt_util.now(),
                 },
                 blocking=True,
             )
@@ -704,7 +704,7 @@ class Test_delete_passcode:
 
 
 class Test_cleanup_passcodes:
-    @pytest.mark.parametrize("return_response", (True, False))
+    @pytest.mark.parametrize("return_response", [True, False])
     async def test_works_when_there_is_nothing_to_do(
         self, hass: HomeAssistant, component_setup, mock_api_responses, return_response
     ) -> None:


### PR DESCRIPTION
Broadens the ruff rule set from ~20 rule groups to the much larger set HA Core lints itself with, and fixes/triages every violation this surfaced across custom_components/ttlock and tests.

Two bugs surfaced:
- passage_mode_active()'s default argument froze "now" at module-import time instead of evaluating it per call
- two _LOGGER.error() calls in api.py were silently dropping their lock_id and error-message arguments due to a mismatched format string.