### PR TITLE
Migrate type checking from mypy to pyright

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -12,6 +12,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+      - name: Install pyright
+        run: npm ci
+      - name: Run pyright
+        run: npx pyright
 
   validate_hacs:
     name: "HACS"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Node (pyright)
+node_modules/
+
 # C extensions
 *.so
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,12 @@ repos:
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+  - repo: local
     hooks:
-      - id: mypy
-        additional_dependencies:
-          - types-dateparser
+      - id: pyright
+        name: pyright
+        entry: npx pyright
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [manual]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jonas Bergler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -87,7 +87,7 @@ class TTLockApi:
         return self._oauth_session.token["access_token"]
 
     async def _add_auth(self, **kwargs) -> dict:
-        kwargs["clientId"] = self._oauth_session.implementation.client_id
+        kwargs["clientId"] = self._oauth_session.implementation.client_id  # pyright: ignore[reportAttributeAccessIssue] - implementation is a TTLockAuthImplementation
         kwargs["accessToken"] = await self.async_get_access_token()
         kwargs["date"] = str(round(time.time() * 1000))
         return kwargs

--- a/custom_components/ttlock/config_flow.py
+++ b/custom_components/ttlock/config_flow.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import DOMAIN
@@ -26,12 +26,12 @@ class TTLockAuthFlowHandler(
 
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Create an entry for auth."""
         # Flow has been triggered by external data
         errors = {}
         if user_input is not None:
-            session = await self.flow_impl.login(
+            session = await self.flow_impl.login(  # pyright: ignore[reportAttributeAccessIssue] - flow_impl is a TTLockAuthImplementation
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )
             if "errmsg" in session:

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -12,8 +12,9 @@ from typing import TypeGuard
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -301,8 +302,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             "unique_id": self.unique_id,
             "device": self.data,
             "entities": [
-                self.hass.states.get(entity.entity_id).as_dict()
+                state.as_dict()
                 for entity in self.entities
+                if (state := self.hass.states.get(entity.entity_id)) is not None
             ],
         }
 

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -405,11 +405,12 @@ class WebhookEvent(BaseModel):
     @property
     def state(self) -> LockState:
         """The end state of the lock after this event."""
+        # pyright can't see the default on the other aliased field when only one is passed
         if self.success and self.event.action == Action.lock:
-            return LockState(state=State.locked)
+            return LockState(state=State.locked)  # pyright: ignore[reportCallIssue]
         if self.success and self.event.action == Action.unlock:
-            return LockState(state=State.unlocked)
-        return LockState(state=None)
+            return LockState(state=State.unlocked)  # pyright: ignore[reportCallIssue]
+        return LockState(state=None)  # pyright: ignore[reportCallIssue]
 
     @property
     def sensorState(self) -> LockState:
@@ -417,8 +418,8 @@ class WebhookEvent(BaseModel):
         if self.success and self.event.action == Action.close:
             return LockState(state=State.locked, sensorState=SensorState.closed)
         if self.success and self.event.action == Action.open:
-            return LockState(sensorState=SensorState.opened)
-        return LockState(sensorState=None)
+            return LockState(sensorState=SensorState.opened)  # pyright: ignore[reportCallIssue]
+        return LockState(sensorState=None)  # pyright: ignore[reportCallIssue]
 
 
 class Features(IntFlag):

--- a/custom_components/ttlock/services.py
+++ b/custom_components/ttlock/services.py
@@ -91,7 +91,7 @@ class Services:
             DOMAIN,
             SVC_CREATE_PASSCODE,
             self.handle_create_passcode,
-            schema=vol.All(
+            schema=vol.All(  # pyright: ignore[reportArgumentType] - vol.All is a valid voluptuous validator
                 vol.Schema(
                     {
                         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
@@ -109,7 +109,7 @@ class Services:
             DOMAIN,
             SVC_MODIFY_PASSCODE,
             self.handle_modify_passcode,
-            schema=vol.All(
+            schema=vol.All(  # pyright: ignore[reportArgumentType] - vol.All is a valid voluptuous validator
                 vol.Schema(
                     {
                         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
@@ -252,9 +252,11 @@ class Services:
 
     async def handle_configure_passage_mode(self, call: ServiceCall):
         """Enable passage mode for the given entities."""
-        start_time = call.data.get(CONF_START_TIME)
-        end_time = call.data.get(CONF_END_TIME)
-        days = [WEEKDAYS.index(day) + 1 for day in call.data.get(CONF_WEEK_DAYS)]
+        start_time = call.data.get(CONF_START_TIME, time())
+        end_time = call.data.get(CONF_END_TIME, time())
+        days = [
+            WEEKDAYS.index(day) + 1 for day in call.data.get(CONF_WEEK_DAYS, WEEKDAYS)
+        ]
 
         config = PassageModeConfig(
             passageMode=OnOff.on if call.data.get(CONF_ENABLED) else OnOff.off,
@@ -321,7 +323,7 @@ class Services:
             endDate=end_time,
         )
 
-        passcode_id = call.data.get("passcode_id")
+        passcode_id = call.data["passcode_id"]
 
         for coordinator in self._get_coordinators(call).values():
             await coordinator.api.modify_passcode(
@@ -331,7 +333,7 @@ class Services:
     async def handle_delete_passcode(self, call: ServiceCall):
         """Delete a specific passcode from the given entities."""
 
-        passcode_id = call.data.get("passcode_id")
+        passcode_id = call.data["passcode_id"]
 
         for coordinator in self._get_coordinators(call).values():
             await coordinator.api.delete_passcode(coordinator.lock_id, passcode_id)

--- a/custom_components/ttlock/webhook.py
+++ b/custom_components/ttlock/webhook.py
@@ -126,7 +126,7 @@ class WebhookHandler:
             if data := await request.post():
                 _LOGGER.debug("Got webhook data: %s", data)
                 for raw_records in data.getall("records", []):
-                    for record in json.loads(raw_records):
+                    for record in json.loads(raw_records):  # pyright: ignore[reportArgumentType] - always a JSON string, never a file upload
                         async_dispatcher_send(
                             hass, SIGNAL_NEW_DATA, WebhookEvent.model_validate(record)
                         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "hass-ttlock",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hass-ttlock",
+      "devDependencies": {
+        "pyright": "1.1.411"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pyright": {
+      "version": "1.1.411",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.411.tgz",
+      "integrity": "sha512-03S/vmS5lF1S/tVbKc2WNXCMq8JWCwta/qIYjj1jvqbQhoy+N3NgBzHTSmUlbYD6DJwqQ5XHf108QujoqeURvw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pyright": "index.js",
+        "pyright-langserver": "langserver.index.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hass-ttlock",
+  "private": true,
+  "devDependencies": {
+    "pyright": "1.1.411"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,16 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = []
 
+[tool.pyright]
+include = ["custom_components/ttlock", "tests"]
+venvPath = "."
+venv = ".venv"
+typeCheckingMode = "basic"
+reportUnusedImport = "none"
+reportUnusedVariable = "none"
+reportUnusedCoroutine = "none"
+reportMissingTypeStubs = "none"
+
 [tool.ruff]
 # Based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 target-version = "py313"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def component_setup(hass: HomeAssistant, config_entry: MockConfigEntry):
 async def api():
     """TTLockApi instance for use in tests."""
     session = ClientSession()
-    return TTLockApi(session, None)
+    return TTLockApi(session, None)  # pyright: ignore[reportArgumentType] - unused by the tests that consume this fixture
 
 
 @pytest.fixture

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -141,8 +141,10 @@ class TestLockUpdateCoordinator:
             mock_api_responses("with_sensor")
             await coordinator.async_refresh()
 
+            assert coordinator.data.sensor is not None
             assert coordinator.data.sensor.opened is False
             assert coordinator.data.sensor.battery == 85
+            assert coordinator.data.sensor.last_fetched is not None
             assert coordinator.data.sensor.last_fetched > dt_util.now() - timedelta(
                 seconds=3
             )
@@ -153,7 +155,9 @@ class TestLockUpdateCoordinator:
             mock_api_responses("sensor_not_installed")
             await coordinator.async_refresh()
 
+            assert coordinator.data.sensor is not None
             assert coordinator.data.sensor.present is False
+            assert coordinator.data.sensor.last_fetched is not None
             assert coordinator.data.sensor.last_fetched > dt_util.now() - timedelta(
                 seconds=3
             )
@@ -164,9 +168,11 @@ class TestLockUpdateCoordinator:
             mock_api_responses("with_sensor")
 
             await coordinator.async_refresh()
+            assert coordinator.data.sensor is not None
             t0 = coordinator.data.sensor.last_fetched
 
             await coordinator.async_refresh()
+            assert coordinator.data.sensor is not None
             t1 = coordinator.data.sensor.last_fetched
 
             assert t0 == t1
@@ -237,6 +243,7 @@ class TestLockUpdateCoordinator:
 
             coordinator.data.locked = True
             coordinator.data.auto_lock_seconds = -1
+            assert coordinator.data.sensor is not None
             coordinator.data.sensor.opened = False
 
             event = WebhookEvent.model_validate(WEBHOOK_SENSOR_OPEN)
@@ -253,6 +260,7 @@ class TestLockUpdateCoordinator:
 
             coordinator.data.locked = False
             coordinator.data.auto_lock_seconds = -1
+            assert coordinator.data.sensor is not None
             coordinator.data.sensor.opened = True
 
             event = WebhookEvent.model_validate(WEBHOOK_SENSOR_CLOSE)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -99,8 +99,8 @@ class Test_list_passcodes:
             keyboardPwdType=PasscodeType.temporary,
             keyboardPwdName="Test Code",
             keyboardPwd="123456",
-            startDate=int(start_time.timestamp() * 1000),
-            endDate=int(end_time.timestamp() * 1000),
+            startDate=int(start_time.timestamp() * 1000),  # pyright: ignore[reportArgumentType] - EpochMs coerces from an int at runtime
+            endDate=int(end_time.timestamp() * 1000),  # pyright: ignore[reportArgumentType] - EpochMs coerces from an int at runtime
         )
 
         with patch(
@@ -171,12 +171,11 @@ class Test_list_records:
             recordId=123,
             lockId=15450395,
             recordType=RecordType.PASSWORD_UNLOCK,
-            recordTypeFromLock=7,
             success=False,
             username="test",
             keyboardPwd="123456",
-            lockDate=int(dt_util.now().timestamp() * 1000),
-            serverDate=int(dt_util.now().timestamp() * 1000),
+            lockDate=int(dt_util.now().timestamp() * 1000),  # pyright: ignore[reportArgumentType] - EpochMs coerces from an int at runtime
+            serverDate=int(dt_util.now().timestamp() * 1000),  # pyright: ignore[reportArgumentType] - EpochMs coerces from an int at runtime
         )
 
         with patch(
@@ -752,7 +751,7 @@ class Test_cleanup_passcodes:
             patch(
                 "custom_components.ttlock.api.TTLockApi.list_passcodes",
                 return_value=[
-                    Passcode(
+                    Passcode(  # pyright: ignore[reportCallIssue] - other aliased fields default to None
                         keyboardPwdId=123,
                         keyboardPwdType=PasscodeType.temporary,
                         keyboardPwdName="Test",


### PR DESCRIPTION
Adds a [tool.pyright] config (basic mode) and installs pyright via npm, replacing the mypy pre-commit hook. Fixes/triages every pyright error this surfaced: two genuine bugs (a stale DeviceInfo import path, and diagnostics.as_dict() crashing when hass.states.get() returns None for a stale entity), several real Optional-handling gaps in services.py and tests, and narrow pyright: ignore suppressions for known false positives (voluptuous's vol.All as a service schema, pydantic aliased-field defaults pyright can't see, HA's abstract OAuth2Implementation typing).

The pyright pre-commit hook itself is manual-stage (too slow for every commit, same as the reference blueprint's own convention), so it's also wired into the "pre-commit" CI job directly to make sure it actually runs somewhere automated rather than only on a human's local machine.

Also adds an MIT LICENSE file.