### PR TITLE
Migrate type checking from mypy to Astral's ty

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -9,8 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.0
 
   validate_hacs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,7 @@ repos:
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.61
     hooks:
-      - id: mypy
-        additional_dependencies:
-          - types-dateparser
+      - id: ty

--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -87,7 +87,7 @@ class TTLockApi:
         return self._oauth_session.token["access_token"]
 
     async def _add_auth(self, **kwargs) -> dict:
-        kwargs["clientId"] = self._oauth_session.implementation.client_id
+        kwargs["clientId"] = self._oauth_session.implementation.client_id  # ty: ignore[unresolved-attribute] - implementation is a TTLockAuthImplementation
         kwargs["accessToken"] = await self.async_get_access_token()
         kwargs["date"] = str(round(time.time() * 1000))
         return kwargs

--- a/custom_components/ttlock/config_flow.py
+++ b/custom_components/ttlock/config_flow.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import DOMAIN
@@ -14,7 +14,7 @@ from .const import DOMAIN
 
 class TTLockAuthFlowHandler(
     config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
-):  # type: ignore[call-arg]
+):
     """Config flow to handle TTLock OAuth2 authentication."""
 
     DOMAIN = DOMAIN
@@ -26,12 +26,12 @@ class TTLockAuthFlowHandler(
 
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Create an entry for auth."""
         # Flow has been triggered by external data
         errors = {}
         if user_input is not None:
-            session = await self.flow_impl.login(
+            session = await self.flow_impl.login(  # ty: ignore[unresolved-attribute] - flow_impl is a TTLockAuthImplementation
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )
             if "errmsg" in session:

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -289,11 +289,12 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
     @property
     def entities(self) -> list[Entity]:
         """Entities belonging to this co-ordinator."""
-        return [
-            callback.__self__
-            for callback, _ in list(self._listeners.values())
-            if isinstance(callback.__self__, Entity)
-        ]
+        result: list[Entity] = []
+        for listener_callback, _ in list(self._listeners.values()):
+            owner = listener_callback.__self__  # ty: ignore[unresolved-attribute] - checking for bound-method listeners
+            if isinstance(owner, Entity):
+                result.append(owner)
+        return result
 
     def as_dict(self) -> dict:
         """Serialize for diagnostics."""
@@ -301,8 +302,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             "unique_id": self.unique_id,
             "device": self.data,
             "entities": [
-                self.hass.states.get(entity.entity_id).as_dict()
+                state.as_dict()
                 for entity in self.entities
+                if (state := self.hass.states.get(entity.entity_id)) is not None
             ],
         }
 

--- a/custom_components/ttlock/services.py
+++ b/custom_components/ttlock/services.py
@@ -91,7 +91,7 @@ class Services:
             DOMAIN,
             SVC_CREATE_PASSCODE,
             self.handle_create_passcode,
-            schema=vol.All(
+            schema=vol.All(  # ty: ignore[invalid-argument-type] - vol.All is a valid voluptuous validator
                 vol.Schema(
                     {
                         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
@@ -109,7 +109,7 @@ class Services:
             DOMAIN,
             SVC_MODIFY_PASSCODE,
             self.handle_modify_passcode,
-            schema=vol.All(
+            schema=vol.All(  # ty: ignore[invalid-argument-type] - vol.All is a valid voluptuous validator
                 vol.Schema(
                     {
                         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
@@ -241,20 +241,24 @@ class Services:
                     "id": code.id,
                     "passcode": code.passcode,
                     "type": code.type.name if code.type is not None else None,
-                    "start_date": code.start_date,
-                    "end_date": code.end_date,
+                    "start_date": code.start_date.isoformat()
+                    if code.start_date
+                    else None,
+                    "end_date": code.end_date.isoformat() if code.end_date else None,
                     "expired": code.expired,
                 }
                 for code in codes
             ]
 
-        return {"passcodes": passcodes}
+        return {"passcodes": passcodes}  # ty: ignore[invalid-return-type] - dict/list generics are invariant, so this structurally-JSON-safe dict isn't recognized as a dict[str, JsonValueType] subtype
 
     async def handle_configure_passage_mode(self, call: ServiceCall):
         """Enable passage mode for the given entities."""
-        start_time = call.data.get(CONF_START_TIME)
-        end_time = call.data.get(CONF_END_TIME)
-        days = [WEEKDAYS.index(day) + 1 for day in call.data.get(CONF_WEEK_DAYS)]
+        start_time = call.data.get(CONF_START_TIME, time())
+        end_time = call.data.get(CONF_END_TIME, time())
+        days = [
+            WEEKDAYS.index(day) + 1 for day in call.data.get(CONF_WEEK_DAYS, WEEKDAYS)
+        ]
 
         config = PassageModeConfig(
             passageMode=OnOff.on if call.data.get(CONF_ENABLED) else OnOff.off,
@@ -321,7 +325,7 @@ class Services:
             endDate=end_time,
         )
 
-        passcode_id = call.data.get("passcode_id")
+        passcode_id = call.data["passcode_id"]
 
         for coordinator in self._get_coordinators(call).values():
             await coordinator.api.modify_passcode(
@@ -331,17 +335,17 @@ class Services:
     async def handle_delete_passcode(self, call: ServiceCall):
         """Delete a specific passcode from the given entities."""
 
-        passcode_id = call.data.get("passcode_id")
+        passcode_id = call.data["passcode_id"]
 
         for coordinator in self._get_coordinators(call).values():
             await coordinator.api.delete_passcode(coordinator.lock_id, passcode_id)
 
     async def handle_cleanup_passcodes(self, call: ServiceCall) -> ServiceResponse:
         """Clean up expired passcodes for the given entities."""
-        removed = {}
+        removed: dict[str, list[str | None]] = {}
 
         for entity_id, coordinator in self._get_coordinators(call).items():
-            removed_for_lock = []
+            removed_for_lock: list[str | None] = []
             codes = await coordinator.api.list_passcodes(coordinator.lock_id)
             for code in codes:
                 if code.expired and code.id is not None:
@@ -352,7 +356,7 @@ class Services:
             if removed_for_lock:
                 removed[entity_id] = removed_for_lock
 
-        return {"removed": removed}
+        return {"removed": removed}  # ty: ignore[invalid-return-type] - dict/list generics are invariant, so dict[str, list[str | None]] isn't recognized as a dict[str, JsonValueType] subtype even though every value is one
 
     async def handle_configure_autolock(self, call: ServiceCall):
         """Set the autolock seconds."""
@@ -396,13 +400,17 @@ class Services:
                     "success": record.success,
                     "username": record.username,
                     "keyboard_pwd": record.keyboard_pwd,
-                    "lock_date": record.lock_date,
-                    "server_date": record.server_date,
+                    "lock_date": record.lock_date.isoformat()
+                    if record.lock_date
+                    else None,
+                    "server_date": record.server_date.isoformat()
+                    if record.server_date
+                    else None,
                 }
                 for record in lock_records
             ]
 
-        return {"records": records}
+        return {"records": records}  # ty: ignore[invalid-return-type] - dict/list generics are invariant, so this structurally-JSON-safe dict isn't recognized as a dict[str, JsonValueType] subtype
 
     async def handle_update_state(self, call: ServiceCall):
         """Refresh the lock state by calling the coordinator's refresh method."""

--- a/custom_components/ttlock/webhook.py
+++ b/custom_components/ttlock/webhook.py
@@ -126,7 +126,7 @@ class WebhookHandler:
             if data := await request.post():
                 _LOGGER.debug("Got webhook data: %s", data)
                 for raw_records in data.getall("records", []):
-                    for record in json.loads(raw_records):
+                    for record in json.loads(raw_records):  # ty: ignore[invalid-argument-type] - always a JSON string, never a file upload
                         async_dispatcher_send(
                             hass, SIGNAL_NEW_DATA, WebhookEvent.model_validate(record)
                         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ dependencies = [
     "homeassistant>=2025.12.4",
 ]
 
+[tool.ty.environment]
+python-version = "3.13"
+
 [tool.pytest.ini_options]
 log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
@@ -214,4 +217,5 @@ combine-as-imports = true
 dev = [
     "dateparser>=1.2.2",
     "pytest-homeassistant-custom-component>=0.13.301",
+    "ty>=0.0.61",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def component_setup(hass: HomeAssistant, config_entry: MockConfigEntry):
 async def api():
     """TTLockApi instance for use in tests."""
     session = ClientSession()
-    return TTLockApi(session, None)
+    return TTLockApi(session, None)  # ty: ignore[invalid-argument-type] - unused by the tests that consume this fixture
 
 
 @pytest.fixture

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -141,8 +141,10 @@ class TestLockUpdateCoordinator:
             mock_api_responses("with_sensor")
             await coordinator.async_refresh()
 
+            assert coordinator.data.sensor is not None
             assert coordinator.data.sensor.opened is False
             assert coordinator.data.sensor.battery == 85
+            assert coordinator.data.sensor.last_fetched is not None
             assert coordinator.data.sensor.last_fetched > dt_util.now() - timedelta(
                 seconds=3
             )
@@ -153,7 +155,9 @@ class TestLockUpdateCoordinator:
             mock_api_responses("sensor_not_installed")
             await coordinator.async_refresh()
 
+            assert coordinator.data.sensor is not None
             assert coordinator.data.sensor.present is False
+            assert coordinator.data.sensor.last_fetched is not None
             assert coordinator.data.sensor.last_fetched > dt_util.now() - timedelta(
                 seconds=3
             )
@@ -164,9 +168,11 @@ class TestLockUpdateCoordinator:
             mock_api_responses("with_sensor")
 
             await coordinator.async_refresh()
+            assert coordinator.data.sensor is not None
             t0 = coordinator.data.sensor.last_fetched
 
             await coordinator.async_refresh()
+            assert coordinator.data.sensor is not None
             t1 = coordinator.data.sensor.last_fetched
 
             assert t0 == t1
@@ -237,12 +243,14 @@ class TestLockUpdateCoordinator:
 
             coordinator.data.locked = True
             coordinator.data.auto_lock_seconds = -1
+            assert coordinator.data.sensor is not None
             coordinator.data.sensor.opened = False
 
             event = WebhookEvent.model_validate(WEBHOOK_SENSOR_OPEN)
             coordinator._process_webhook_data(event)
 
             assert coordinator.data.locked is True
+            assert coordinator.data.sensor is not None
             assert coordinator.data.sensor.opened is True
 
         async def test_close_works(
@@ -253,11 +261,13 @@ class TestLockUpdateCoordinator:
 
             coordinator.data.locked = False
             coordinator.data.auto_lock_seconds = -1
+            assert coordinator.data.sensor is not None
             coordinator.data.sensor.opened = True
 
             event = WebhookEvent.model_validate(WEBHOOK_SENSOR_CLOSE)
             coordinator._process_webhook_data(event)
 
             assert coordinator.data.locked is True
+            assert coordinator.data.sensor is not None
             assert coordinator.data.sensor.opened is False
             assert coordinator.data.last_reason == "Door Closed"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -117,6 +117,8 @@ class Test_list_passcodes:
             await hass.async_block_till_done()
             assert mock.called
 
+        assert passcode.start_date is not None
+        assert passcode.end_date is not None
         assert response == {
             "passcodes": {
                 entity_id: [
@@ -125,8 +127,8 @@ class Test_list_passcodes:
                         "id": 123,
                         "passcode": "123456",
                         "type": "period",
-                        "start_date": passcode.start_date,
-                        "end_date": passcode.end_date,
+                        "start_date": passcode.start_date.isoformat(),
+                        "end_date": passcode.end_date.isoformat(),
                         "expired": False,
                     }
                 ]
@@ -171,7 +173,6 @@ class Test_list_records:
             recordId=123,
             lockId=15450395,
             recordType=RecordType.PASSWORD_UNLOCK,
-            recordTypeFromLock=7,
             success=False,
             username="test",
             keyboardPwd="123456",
@@ -205,8 +206,12 @@ class Test_list_records:
                         "success": record.success,
                         "username": record.username,
                         "keyboard_pwd": record.keyboard_pwd,
-                        "lock_date": record.lock_date,
-                        "server_date": record.server_date,
+                        "lock_date": record.lock_date.isoformat()
+                        if record.lock_date
+                        else None,
+                        "server_date": record.server_date.isoformat()
+                        if record.server_date
+                        else None,
                     }
                 ]
             }

--- a/uv.lock
+++ b/uv.lock
@@ -1247,6 +1247,7 @@ dependencies = [
 dev = [
     { name = "dateparser" },
     { name = "pytest-homeassistant-custom-component" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -1256,6 +1257,7 @@ requires-dist = [{ name = "homeassistant", specifier = ">=2025.12.4" }]
 dev = [
     { name = "dateparser", specifier = ">=1.2.2" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13.301" },
+    { name = "ty", specifier = ">=0.0.61" },
 ]
 
 [[package]]
@@ -3014,6 +3016,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.61"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/63/6944925d0fe9a4bb9cc744e6c045a42bbd2ee4654c103190674577a36c3f/ty-0.0.61.tar.gz", hash = "sha256:acbf0d914cc7e2e57ccc440036af36114819e2a604a5ffb554e72e4ca7dd65a2", size = 6234957, upload-time = "2026-07-18T01:39:54.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/cf/044f31523e2768e3e64b0ca2ec32f70b3a731d4a2caa6ea110baf26e251c/ty-0.0.61-py3-none-linux_armv6l.whl", hash = "sha256:148779b8675eac93f40ec58bd70037fe67537117f20a23272264f8f136d41336", size = 11891448, upload-time = "2026-07-18T01:39:18.449Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/55/558cfe76b65d91d1854bbfac336020bd42fd887caa632d845d13c0c539eb/ty-0.0.61-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:08217382b3385808ee7288501ea3214b32631b08d1fd091ece6799b0c95264c5", size = 11602442, upload-time = "2026-07-18T01:39:20.914Z" },
+    { url = "https://files.pythonhosted.org/packages/27/be/78c0ae6634cd606a68e5b46b338db427a48a1800c96a749b2d2f7a702e03/ty-0.0.61-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6d99c729011b47dec20e78a32ac9c8f6defd4cf62f7bb851bbccf70dde6cee50", size = 11125286, upload-time = "2026-07-18T01:39:22.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/a40793962f1b6337938ddb0bca7496b54e70879e23b4d2cc8dfd7e5d1af3/ty-0.0.61-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cda607978ae271b77e51c947663218bce635c3507e256865444b10c37cdb60d", size = 11663403, upload-time = "2026-07-18T01:39:25.017Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c1/7879244da5b30407dc368946d36be5024380073408b079f144ffe034030e/ty-0.0.61-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d78f160a0f9434d570cdcdbc4dafba1f6aac3c47a32f9f63995b3cb55ffe4b6", size = 11715250, upload-time = "2026-07-18T01:39:27.045Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/8a4637cd58abd37f315dd515e24c582986cb1bfdf2edc4786882f5a4f69a/ty-0.0.61-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09aeab4800b36e93e4ce918699004da642d74988cac920b7592a6a2b9be6611c", size = 12393876, upload-time = "2026-07-18T01:39:29.197Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4b/27e7c640b1272743503229aa17ae2167a538040c4716a2fa1777c2b34fea/ty-0.0.61-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dccc8136df44142a109953a168be17b4915c99876b047d0b6672c31dae939bdf", size = 12958187, upload-time = "2026-07-18T01:39:31.308Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f5/70eaaefb6081fb0a8115cff66fbfaa20dafac8c646df2477adad95a59de2/ty-0.0.61-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:220760c2d13a887d027ee1093172c24ac35b6e634805329c93a30908ae4d3f5c", size = 12560101, upload-time = "2026-07-18T01:39:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/17bae3b6429b5c479dc6c1e344d34e1f79efbc27531f15f3ee5b5da63745/ty-0.0.61-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:effefbb89da7128d18059529d1c2ea390fe7f1f3882690d257ca2143d49a0c34", size = 12225389, upload-time = "2026-07-18T01:39:35.436Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/2ac380ba20d6395542c8df1d6fa4f00e2aead784c2e6aaefa1e02ed0610c/ty-0.0.61-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ba8b28a5ef811d5bb6461e37d76110c06fd20487474865c323d3d18b08b972b2", size = 12548403, upload-time = "2026-07-18T01:39:37.556Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e5/7da4b73e825e1a9808c26d68b0156e9a37aede1846191210dfffb8c64042/ty-0.0.61-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:88ecd6d9b05e8174b1860dac9bd3e188d6cef5702b0d3239fd9f94f6ac73a29d", size = 11621813, upload-time = "2026-07-18T01:39:39.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/5b58015e998cd0d89b17a463b6321421457d86d987574e8dac65ddfceba3/ty-0.0.61-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb0cdfe4c48542ffb9a1139825dfa3d4aae49e96e966682ef7da762ab97831ff", size = 11734101, upload-time = "2026-07-18T01:39:42.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/21/294f4cc819b7b12ed659fd860e5cdfbd592d4c768c8f23596685dbc43e6b/ty-0.0.61-py3-none-musllinux_1_2_i686.whl", hash = "sha256:dff03873c0c3d0b44738f8b6d403b0756a31cf54c65136397df7624c6159b1f0", size = 11988401, upload-time = "2026-07-18T01:39:44.183Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/26/0f96f79fdac118521a9771e9eef3f9b3f447d647b2c77953e80a1715c7e8/ty-0.0.61-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a9210e80e3d41c1dfc751e9e8e0980272f475031fafd0fb0f48aee233c78da03", size = 12330624, upload-time = "2026-07-18T01:39:46.662Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/08/1e62d1bca5c0cebdc7a34db1f4b61557aab85961cedd56953dd2c32d3e66/ty-0.0.61-py3-none-win32.whl", hash = "sha256:e3e1fe06f49a5492a922a5df2739834aa5ee978c7dd10414119dc8755cc40c9c", size = 11313991, upload-time = "2026-07-18T01:39:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/26/f1/d8e33b3aeb36b73d81ae34d10e46ec4abf506d68f4e0a1491a76a593dd42/ty-0.0.61-py3-none-win_amd64.whl", hash = "sha256:25f2291169e0298fcdbba1b1fea64f8207a6c1908dddef32346fd5e3e6ac9221", size = 12311717, upload-time = "2026-07-18T01:39:50.881Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/14/7caec26d93a943c0e7d15eb7374644508d08cbd387d112b722b12d14e044/ty-0.0.61-py3-none-win_arm64.whl", hash = "sha256:3e496f7698bc4b5bbb1eb66d8b5799ba87596d88d36604ca359083893fa2fc49", size = 11693485, upload-time = "2026-07-18T01:39:52.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds ty as a uv dev-dependency (no npm/node needed, unlike pyright) with a [tool.ty.environment] config, and swaps the mypy pre-commit hook for the official astral-sh/ty-pre-commit hook. ty runs in ~0.15s, so it's wired in at the default commit stage rather than mypy's hosted hook's usual pace, and needs no separate manual CI step.

Fixes/triages every diagnostic ty surfaced: several real Optional- handling gaps (same class of bug the mypy hook's isolated, dependency- free venv was too weak to catch), a stale DeviceInfo import, and diagnostics.as_dict() crashing on a stale entity_id. Also fixes a genuine API inconsistency ty caught that mypy/pyright both missed: handle_list_passcodes and handle_list_records were returning raw datetime objects in a ServiceResponse instead of ISO-formatted strings, unlike HA core's own calendar integration convention - verified HA's websocket JSON encoder tolerates raw datetimes so this wasn't a live bug, but it's now fixed to match convention rather than just suppressed.

Where ty's diagnostics are genuine tool/stub-precision limitations (voluptuous's vol.All as a schema, HA's abstract OAuth2Implementation typing, dict/list generic invariance against the recursive JsonValueType alias), added narrow `ty: ignore[rule]` comments instead.