### PR TITLE
Show non-connectable locks as unavailable, load locks progressively, re-verify lock state

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -23,6 +23,8 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 
+DETAIL_FILL_CONCURRENCY = 3
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -32,6 +34,21 @@ def setup(hass: HomeAssistant, config: ConfigEntry) -> bool:
     Services(hass).register()
 
     return True
+
+
+async def _fill_lock_details(locks: list[LockUpdateCoordinator]) -> None:
+    """Progressively fetch full per-lock detail in the background after setup.
+
+    Bounded concurrency so many locks don't all hit the TTLock cloud API at
+    once - this is about smooth progressive loading, not rate-limiting.
+    """
+    semaphore = asyncio.Semaphore(DETAIL_FILL_CONCURRENCY)
+
+    async def _refresh_one(coordinator: LockUpdateCoordinator) -> None:
+        async with semaphore:
+            await coordinator.async_refresh()
+
+    await asyncio.gather(*(_refresh_one(coordinator) for coordinator in locks))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -48,12 +65,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {TT_API: client}
 
     locks = [
-        LockUpdateCoordinator(hass, entry, client, lock_id)
-        for lock_id in await client.get_locks()
+        LockUpdateCoordinator(hass, entry, client, summary)
+        for summary in await client.get_locks()
     ]
-    await asyncio.gather(
-        *[coordinator.async_config_entry_first_refresh() for coordinator in locks]
-    )
     hass.data[DOMAIN][entry.entry_id][TT_LOCKS] = locks
 
     gateway_coordinator = GatewaysUpdateCoordinator(hass, entry, client)
@@ -63,6 +77,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await WebhookHandler(hass, entry).setup()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    if skipped := [coordinator for coordinator in locks if not coordinator.connectable]:
+        _LOGGER.warning(
+            "%d lock(s) have no gateway or WiFi and will show as unavailable "
+            "until connectivity is restored: %s",
+            len(skipped),
+            ", ".join(
+                f"{coordinator.data.name} ({coordinator.lock_id})"
+                for coordinator in skipped
+            ),
+        )
+
+    connectable_locks = [
+        coordinator for coordinator in locks if coordinator.connectable
+    ]
+    entry.async_create_background_task(
+        hass,
+        _fill_lock_details(connectable_locks),
+        name=f"ttlock-{entry.entry_id}-initial-detail-fill",
+    )
 
     return True
 

--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -17,11 +17,11 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from .models import (
     AddPasscodeConfig,
-    Features,
     Gateway,
     Lock,
     LockRecord,
     LockState,
+    LockSummary,
     PassageModeConfig,
     Passcode,
     Sensor,
@@ -140,18 +140,10 @@ class TTLockApi:
         )
         return await self._parse_resp(resp, log_id)
 
-    async def get_locks(self) -> list[int]:
-        """Enumerate all locks in the account."""
+    async def get_locks(self) -> list[LockSummary]:
+        """Enumerate all locks in the account (connectable and not)."""
         res = await self.get("lock/list", pageNo=1, pageSize=1000)
-
-        def lock_connectable(lock) -> bool:
-            has_gateway = lock.get("hasGateway") != 0
-            has_wifi = Features.wifi in Features.from_feature_value(
-                lock.get("featureValue")
-            )
-            return has_gateway or has_wifi
-
-        return [lock["lockId"] for lock in res["list"] if lock_connectable(lock)]
+        return [LockSummary.model_validate(lock) for lock in res["list"]]
 
     async def get_gateways(self) -> list[Gateway]:
         """Enumerate all gateways in the account."""

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -12,6 +12,7 @@ from typing import TypeGuard
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -22,6 +23,7 @@ from .const import DOMAIN, SIGNAL_NEW_DATA, TT_GATEWAYS, TT_LOCKS
 from .models import (
     Features,
     Gateway,
+    LockSummary,
     PassageModeConfig,
     SensorState,
     State,
@@ -29,6 +31,11 @@ from .models import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+NOT_CONNECTABLE_REASON = (
+    "No gateway paired and no WiFi — TTLock's cloud can't reach this lock. "
+    "Live data isn't available until connectivity is restored."
+)
 
 
 @dataclass
@@ -150,35 +157,43 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         hass: HomeAssistant,
         config_entry: ConfigEntry,
         api: TTLockApi,
-        lock_id: int,
+        summary: LockSummary,
     ) -> None:
         """Initialize the update co-ordinator for a single lock."""
         self.api = api
-        self.lock_id = lock_id
+        self.lock_id = summary.id
+        self.connectable = summary.connectable
 
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             config_entry=config_entry,
-            update_interval=timedelta(minutes=15),
+            update_interval=timedelta(minutes=15) if self.connectable else None,
+        )
+
+        self.data = LockState(
+            name=summary.name, mac=summary.mac, features=summary.features
         )
 
         async_dispatcher_connect(self.hass, SIGNAL_NEW_DATA, self._process_webhook_data)
 
     async def _async_update_data(self) -> LockState:
+        if not self.connectable:
+            raise UpdateFailed(
+                f"Lock {self.lock_id} has no gateway or WiFi connectivity"
+            )
+
         try:
             details = await self.api.get_lock(self.lock_id)
 
-            new_data = deepcopy(self.data) or LockState(
-                name=details.name,
-                mac=details.mac,
-                model=details.model,
-                features=Features.from_feature_value(details.featureValue),
-            )
+            new_data = deepcopy(self.data)
 
             # update mutable attributes
             new_data.name = details.name
+            new_data.mac = details.mac
+            new_data.model = details.model
+            new_data.features = Features.from_feature_value(details.featureValue)
             new_data.battery_level = details.battery_level
             new_data.hardware_version = details.hardwareRevision
             new_data.firmware_version = details.firmwareRevision
@@ -200,14 +215,22 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             else:
                 new_data.sensor = None
 
-            if new_data.locked is None:
-                try:
-                    state = await self.api.get_lock_state(self.lock_id)
-                    new_data.locked = state.locked == State.locked
-                    if sensor_present(new_data.sensor):
-                        new_data.sensor.opened = state.opened == SensorState.opened
-                except Exception:  # noqa: BLE001 - lock/sensor state fetch is best-effort
-                    _LOGGER.debug("Failed to fetch lock state", exc_info=True)
+            try:
+                state = await self.api.get_lock_state(self.lock_id)
+                new_data.locked = state.locked == State.locked
+                if sensor_present(new_data.sensor):
+                    new_data.sensor.opened = state.opened == SensorState.opened
+            except Exception as err:
+                if new_data.locked is None:
+                    # first-ever fetch: tolerate failure, entity shows "unknown"
+                    _LOGGER.debug("Failed to fetch initial lock state", exc_info=True)
+                else:
+                    # we previously had a verified state - a failure to re-verify now
+                    # means we can no longer trust it (e.g. gateway/webhooks silently
+                    # died), so surface it via the standard unavailable path
+                    raise UpdateFailed(
+                        f"Failed to re-verify lock state for {self.lock_id}"
+                    ) from err
 
             new_data.auto_lock_seconds = details.autoLockTime
             new_data.lock_sound = bool(details.lockSound)
@@ -219,6 +242,20 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             raise UpdateFailed(err) from err
         else:
             return new_data
+
+    @callback
+    def _async_refresh_finished(self) -> None:
+        """Push refreshed device info back into the device registry.
+
+        Entities snapshot `coordinator.device_info` once at add time, so once
+        we start seeding placeholder data and filling it in progressively,
+        this is what keeps the device registry's model/sw_version/hw_version
+        in sync with later successful refreshes.
+        """
+        if self.last_update_success and self.config_entry is not None:
+            dr.async_get(self.hass).async_get_or_create(
+                config_entry_id=self.config_entry.entry_id, **self.device_info
+            )
 
     @callback
     def _process_webhook_data(self, event: WebhookEvent):
@@ -314,6 +351,8 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         """Serialize for diagnostics."""
         return {
             "unique_id": self.unique_id,
+            "connectable": self.connectable,
+            "last_update_success": self.last_update_success,
             "device": self.data,
             "entities": [
                 state.as_dict()

--- a/custom_components/ttlock/diagnostics.py
+++ b/custom_components/ttlock/diagnostics.py
@@ -32,7 +32,7 @@ def build_diagnostics_dict(d: dict) -> dict[str, Any]:
         if isinstance(d[k], Enum):
             d[k] = f"{d[k].name} ({d[k].value})"
         elif isinstance(d[k], BaseModel):
-            d[k] = build_diagnostics_dict(d[k].dict())
+            d[k] = build_diagnostics_dict(d[k].model_dump())
         elif is_dataclass(d[k]):
             d[k] = build_diagnostics_dict(asdict(d[k]))
     return d

--- a/custom_components/ttlock/entity.py
+++ b/custom_components/ttlock/entity.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import LockUpdateCoordinator
+from .coordinator import NOT_CONNECTABLE_REASON, LockUpdateCoordinator
 
 
 class BaseLockEntity(CoordinatorEntity[LockUpdateCoordinator], ABC):
@@ -38,3 +39,15 @@ class BaseLockEntity(CoordinatorEntity[LockUpdateCoordinator], ABC):
         """Handle updated data from the coordinator."""
         self._update_from_coordinator()
         self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Unavailable if non-connectable, or periodic re-verification is failing."""
+        return self.coordinator.connectable and super().available
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Explain why the entity is unavailable, if it is non-connectable."""
+        if self.coordinator.connectable:
+            return None
+        return {"unavailable_reason": NOT_CONNECTABLE_REASON}

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -87,6 +87,26 @@ class Lock(BaseModel):
     noKeyPwd: str = Field(alias="adminPwd")
 
 
+class LockSummary(BaseModel):
+    """Cheap per-lock summary from lock/list, enough to build a device/entities without a detail fetch."""
+
+    id: int = Field(..., alias="lockId")
+    name: str = Field("Lock", alias="lockAlias")
+    mac: str = Field(..., alias="lockMac")
+    featureValue: str | None = None
+    hasGateway: int = 0
+
+    @property
+    def features(self) -> "Features":
+        """Parse the feature bitmask."""
+        return Features.from_feature_value(self.featureValue)
+
+    @property
+    def connectable(self) -> bool:
+        """True if the lock is reachable via a gateway or its own WiFi."""
+        return self.hasGateway != 0 or Features.wifi in self.features
+
+
 class Sensor(BaseModel):
     """sensor details."""
 

--- a/custom_components/ttlock/switch.py
+++ b/custom_components/ttlock/switch.py
@@ -40,7 +40,7 @@ class AutoLock(BaseLockEntity, SwitchEntity):
     @property
     def extra_state_attributes(self):
         """Define any extra state sttr."""
-        attributes = {}
+        attributes = dict(super().extra_state_attributes or {})
         attributes["seconds"] = self.coordinator.data.auto_lock_seconds
         return attributes
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from custom_components.ttlock.models import (
     Lock,
     LockRecord,
     LockState,
+    LockSummary,
     PassageModeConfig,
     Sensor,
 )
@@ -89,6 +90,7 @@ def component_setup(hass: HomeAssistant, config_entry: MockConfigEntry):
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         return hass.data[DOMAIN][config_entry.entry_id][TT_LOCKS][0]
 
@@ -106,7 +108,11 @@ async def api():
 async def coordinator(hass, api):
     """Co-ordinator instance for use in tests."""
     config_entry = MockConfigEntry(domain=DOMAIN)
-    return LockUpdateCoordinator(hass, config_entry, api, 7252408)
+    config_entry.add_to_hass(hass)
+    summary = LockSummary(
+        lockId=7252408, lockAlias="Test Lock", lockMac="00:00:00:00:00:00", hasGateway=1
+    )
+    return LockUpdateCoordinator(hass, config_entry, api, summary)
 
 
 class MockApiData(NamedTuple):
@@ -167,7 +173,15 @@ def mock_api_responses(monkeypatch, mock_data_factory):
         mock_data = mock_data_factory(scenario)
 
         async def mock_get_locks(*args, **kwargs):
-            return [mock_data.lock.id]
+            return [
+                LockSummary(
+                    lockId=mock_data.lock.id,
+                    lockAlias=mock_data.lock.name,
+                    lockMac=mock_data.lock.mac,
+                    featureValue=mock_data.lock.featureValue,
+                    hasGateway=1,
+                )
+            ]
 
         async def mock_get_lock(*args, **kwargs):
             return mock_data.lock

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,13 +5,22 @@ from datetime import timedelta
 
 import dateparser
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.ttlock.api import RequestFailed
+from custom_components.ttlock.const import DOMAIN
 from custom_components.ttlock.coordinator import LockState, LockUpdateCoordinator
-from custom_components.ttlock.models import PassageModeConfig, WebhookEvent
+from custom_components.ttlock.models import (
+    LockState as WireLockState,
+    LockSummary,
+    PassageModeConfig,
+    WebhookEvent,
+)
 from homeassistant.util import dt as dt_util
 
 from .const import (
     BASIC_LOCK_DETAILS,
+    LOCK_STATE_LOCKED,
     PASSAGE_MODE_6_TO_6_7_DAYS,
     PASSAGE_MODE_ALL_DAY_WEEKDAYS,
     WEBHOOK_LOCK_10AM_UTC,
@@ -176,6 +185,89 @@ class TestLockUpdateCoordinator:
             t1 = coordinator.data.sensor.last_fetched
 
             assert t0 == t1
+
+        async def test_locked_state_reverified_every_refresh(
+            self,
+            coordinator: LockUpdateCoordinator,
+            mock_api_responses,
+            monkeypatch,
+        ):
+            mock_api_responses("default")
+            await coordinator.async_refresh()
+            assert coordinator.data.locked is False
+
+            async def mock_get_lock_state_locked(*args, **kwargs):
+                return WireLockState.model_validate(LOCK_STATE_LOCKED)
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_lock_state",
+                mock_get_lock_state_locked,
+            )
+
+            await coordinator.async_refresh()
+            assert coordinator.data.locked is True
+
+        async def test_first_lock_state_fetch_failure_tolerated(
+            self,
+            coordinator: LockUpdateCoordinator,
+            mock_api_responses,
+            monkeypatch,
+        ):
+            mock_api_responses("default")
+
+            async def mock_get_lock_state_fails(*args, **kwargs):
+                raise RequestFailed("boom")
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_lock_state",
+                mock_get_lock_state_fails,
+            )
+
+            await coordinator.async_refresh()
+
+            assert coordinator.data.locked is None
+            assert coordinator.last_update_success is True
+
+        async def test_lock_state_reverification_failure_marks_unavailable(
+            self,
+            coordinator: LockUpdateCoordinator,
+            mock_api_responses,
+            monkeypatch,
+        ):
+            mock_api_responses("default")
+            await coordinator.async_refresh()
+            assert coordinator.data.locked is False
+            assert coordinator.last_update_success is True
+
+            async def mock_get_lock_state_fails(*args, **kwargs):
+                raise RequestFailed("boom")
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_lock_state",
+                mock_get_lock_state_fails,
+            )
+
+            await coordinator.async_refresh()
+
+            assert coordinator.last_update_success is False
+
+        async def test_non_connectable_lock_never_polled(self, hass, api):
+            config_entry = MockConfigEntry(domain=DOMAIN)
+            config_entry.add_to_hass(hass)
+            summary = LockSummary(
+                lockId=1,
+                lockAlias="No Gateway",
+                lockMac="00:00:00:00:00:01",
+                hasGateway=0,
+            )
+            coordinator = LockUpdateCoordinator(hass, config_entry, api, summary)
+
+            assert coordinator.connectable is False
+            assert coordinator.update_interval is None
+
+            await coordinator.async_refresh()
+
+            assert coordinator.last_update_success is False
 
     class TestProcessWebhookData:
         async def test_lock_works(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,46 @@
+"""Test ttlock diagnostics."""
+
+from custom_components.ttlock.const import DOMAIN
+from custom_components.ttlock.diagnostics import async_get_config_entry_diagnostics
+from custom_components.ttlock.models import LockSummary
+from homeassistant.core import HomeAssistant
+
+
+async def test_diagnostics_includes_connectable_and_health(
+    hass: HomeAssistant, component_setup, mock_api_responses, monkeypatch
+):
+    """Diagnostics surface connectable and last_update_success for troubleshooting."""
+    mock_api_responses("default")
+
+    async def mock_get_locks(*args, **kwargs):
+        return [
+            LockSummary(
+                lockId=7252408,
+                lockAlias="Connectable Lock",
+                lockMac="00:00:00:00:00:01",
+                hasGateway=1,
+            ),
+            LockSummary(
+                lockId=2,
+                lockAlias="No Gateway Lock",
+                lockMac="00:00:00:00:00:02",
+                hasGateway=0,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
+    )
+
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    locks_by_id = {lock["unique_id"]: lock for lock in diagnostics["locks"]}
+    assert locks_by_id[f"{DOMAIN}-7252408"]["connectable"] is True
+    assert locks_by_id[f"{DOMAIN}-7252408"]["last_update_success"] is True
+    # non-connectable coordinators are never refreshed at all (update_interval=None,
+    # excluded from the background detail fill), so last_update_success just sits at
+    # its untouched default - `connectable` is the signal to look at for these.
+    assert locks_by_id[f"{DOMAIN}-2"]["connectable"] is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import patch
 
-from custom_components.ttlock.const import DOMAIN
+from custom_components.ttlock.const import DOMAIN, TT_LOCKS
+from custom_components.ttlock.models import LockSummary
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers.network import NoURLAvailableError
 
@@ -30,3 +31,52 @@ async def test_no_url(hass, component_setup, mock_api_responses):
     with patch("homeassistant.helpers.issue_registry.async_create_issue") as mock:
         assert await component_setup()
         assert mock.assert_called
+
+
+async def test_setup_with_non_connectable_lock(
+    hass, component_setup, mock_api_responses, monkeypatch, caplog
+):
+    """Non-connectable locks still get entities, marked unavailable with a reason."""
+    mock_api_responses("default")
+
+    async def mock_get_locks(*args, **kwargs):
+        return [
+            LockSummary(
+                lockId=7252408,
+                lockAlias="Connectable Lock",
+                lockMac="00:00:00:00:00:01",
+                hasGateway=1,
+            ),
+            LockSummary(
+                lockId=2,
+                lockAlias="No Gateway Lock",
+                lockMac="00:00:00:00:00:02",
+                hasGateway=0,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
+    )
+
+    await component_setup()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    entry = entries[0]
+    assert entry.state is ConfigEntryState.LOADED
+
+    coordinators = {
+        coordinator.lock_id: coordinator
+        for coordinator in hass.data[DOMAIN][entry.entry_id][TT_LOCKS]
+    }
+    assert coordinators[7252408].connectable is True
+    assert coordinators[2].connectable is False
+
+    connectable_entity = next(iter(coordinators[7252408].entities))
+    unavailable_entity = next(iter(coordinators[2].entities))
+
+    assert connectable_entity.available is True
+    assert unavailable_entity.available is False
+    assert "unavailable_reason" in unavailable_entity.extra_state_attributes
+
+    assert "1 lock(s) have no gateway or WiFi" in caplog.text


### PR DESCRIPTION
## Summary
- Locks with no gateway/WiFi are no longer silently excluded from setup: they still get a device/entities, marked `unavailable` with an `unavailable_reason` attribute explaining why (instead of Repairs, which isn't actionable for a lock the user can't reach).
- Setup no longer blocks on fetching full detail for every lock in parallel before any entity appears. Entities are created immediately from the cheap `lock/list` response and platforms are forwarded right away; full per-lock detail (battery, sensor, passage mode, etc.) fills in progressively in the background with bounded concurrency, so large accounts don't burst-call the TTLock API and hit rate limits during setup.
- Locked/unlocked state is now re-verified on every poll instead of only once at setup. If re-verification fails after a prior success (e.g. the lock's gateway/WiFi drops and webhooks silently stop), the entity now correctly goes `unavailable` instead of continuing to show an increasingly stale state.
- Along the way, fixed a latent pydantic v1 `.dict()` deprecation bug in `diagnostics.py` (there were previously no diagnostics tests to catch it).

## Test plan
- [x] `script/check` (lint, `ty` type-check, full pytest suite — 96 tests) passes
- [x] New coverage: coordinator re-verification (success → success, success → failure, first-fetch tolerance), non-connectable coordinators never poll, mixed connectable/non-connectable setup, diagnostics fields
- [ ] Manual smoke test in a live HA instance with a real account (multiple locks, at least one without gateway/WiFi) recommended before merge, given the setup-sequence change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2m7aRLbr63raXLnPevMAZ