### PR TITLE
Fix diagnostics OAuth token redaction and stale docstring

### DIFF
--- a/custom_components/ttlock/diagnostics.py
+++ b/custom_components/ttlock/diagnostics.py
@@ -1,4 +1,4 @@
-"""Diagnostics support for Tractive."""
+"""Diagnostics support for TTLock."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from .const import DOMAIN, TT_LOCKS
 from .models import BaseModel
 
 TO_REDACT = {
-    "auth_implementationtoken",
+    "token",
     "lockKey",
     "aesKeyStr",
     "adminPwd",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -44,3 +44,17 @@ async def test_diagnostics_includes_connectable_and_health(
     # excluded from the background detail fill), so last_update_success just sits at
     # its untouched default - `connectable` is the signal to look at for these.
     assert locks_by_id[f"{DOMAIN}-2"]["connectable"] is False
+
+
+async def test_diagnostics_redacts_oauth_token(
+    hass: HomeAssistant, component_setup, mock_api_responses
+):
+    """The config entry's OAuth access/refresh tokens must never appear in the clear."""
+    mock_api_responses("default")
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    token = diagnostics["config_entry"]["data"]["token"]
+    assert token == "**REDACTED**"


### PR DESCRIPTION
## Summary
- `TO_REDACT` in `diagnostics.py` had a bogus `auth_implementationtoken` key instead of `token`, so a diagnostics download included the raw OAuth access/refresh tokens in the clear
- Fixed the module docstring, which still described an unrelated project ("Tractive")
- Added a regression test asserting the config entry's OAuth token is redacted in a diagnostics dump

Closes #285

## Test plan
- [x] `script/check` passes (lint, type-check, full test suite)
- [x] New test `test_diagnostics_redacts_oauth_token` fails against the old key and passes against the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WFcz6fih7vHJbndfhaz4E