### PR TITLE
Add always-on Connectable inputs and gateway status to diagnostics

### DIFF
--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -163,6 +163,8 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         self.api = api
         self.lock_id = summary.id
         self.connectable = summary.connectable
+        self.has_gateway = summary.hasGateway
+        self.feature_value = summary.featureValue
 
         super().__init__(
             hass,
@@ -352,6 +354,8 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         return {
             "unique_id": self.unique_id,
             "connectable": self.connectable,
+            "has_gateway": self.has_gateway,
+            "feature_value": self.feature_value,
             "last_update_success": self.last_update_success,
             "device": self.data,
             "entities": [
@@ -418,3 +422,14 @@ class GatewaysUpdateCoordinator(DataUpdateCoordinator[dict[int, Gateway]]):
             return {gateway.id: gateway for gateway in gateways}
         except Exception as err:
             raise UpdateFailed(err) from err
+
+    def as_dict(self) -> list[dict]:
+        """Serialize for diagnostics."""
+        return [
+            {
+                "id": gateway.id,
+                "name": gateway.name,
+                "is_online": gateway.is_online,
+            }
+            for gateway in (self.data or {}).values()
+        ]

--- a/custom_components/ttlock/diagnostics.py
+++ b/custom_components/ttlock/diagnostics.py
@@ -10,7 +10,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, TT_LOCKS
+from .const import DOMAIN, TT_GATEWAYS, TT_LOCKS
 from .models import BaseModel
 
 TO_REDACT = {
@@ -50,6 +50,7 @@ async def async_get_config_entry_diagnostics(
                 build_diagnostics_dict(coordinator.as_dict())
                 for coordinator in hass.data[DOMAIN][config_entry.entry_id][TT_LOCKS]
             ],
+            "gateways": hass.data[DOMAIN][config_entry.entry_id][TT_GATEWAYS].as_dict(),
         },
         TO_REDACT,
     )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 from custom_components.ttlock.const import DOMAIN
 from custom_components.ttlock.diagnostics import async_get_config_entry_diagnostics
-from custom_components.ttlock.models import LockSummary
+from custom_components.ttlock.models import Gateway, LockSummary
 from homeassistant.core import HomeAssistant
 
 
@@ -58,3 +58,55 @@ async def test_diagnostics_redacts_oauth_token(
 
     token = diagnostics["config_entry"]["data"]["token"]
     assert token == "**REDACTED**"
+
+
+async def test_diagnostics_includes_raw_connectivity_fields_and_gateway_status(
+    hass: HomeAssistant, component_setup, mock_api_responses, monkeypatch
+):
+    """Diagnostics surface the raw lock-list fields behind Connectable, plus gateway status."""
+    mock_api_responses("default")
+
+    async def mock_get_locks(*args, **kwargs):
+        return [
+            LockSummary(
+                lockId=2,
+                lockAlias="No Gateway Lock",
+                lockMac="00:00:00:00:00:02",
+                hasGateway=0,
+                featureValue="000000",
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
+    )
+
+    async def mock_get_gateways(*args, **kwargs):
+        return [
+            Gateway.model_validate(
+                {
+                    "gatewayId": 1461158,
+                    "gatewayName": "Test Gateway",
+                    "gatewayMac": "05:F6:1E:93:8B:2B",
+                    "isOnline": 1,
+                }
+            )
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_gateways", mock_get_gateways
+    )
+
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    lock = diagnostics["locks"][0]
+    assert lock["connectable"] is False
+    assert lock["has_gateway"] == 0
+    assert lock["feature_value"] == "000000"
+
+    gateways = diagnostics["gateways"]
+    assert gateways[0]["name"] == "Test Gateway"
+    assert gateways[0]["is_online"] is True


### PR DESCRIPTION
## Summary
- `LockUpdateCoordinator` now stores `has_gateway`/`feature_value` (raw fields from the lock-list endpoint's `LockSummary`) alongside the existing derived `connectable`, and surfaces them via `as_dict()`
- `GatewaysUpdateCoordinator` gained an `as_dict()` returning each gateway's id/name/online status
- `diagnostics.py`'s config-entry dump now includes a `gateways` key built from the above — no redaction needed, none of this is sensitive

Closes #286

## Test plan
- [x] `script/check` passes (lint, type-check, full test suite)
- [x] New test `test_diagnostics_includes_raw_connectivity_fields_and_gateway_status` covers a non-connectable lock's raw fields and gateway online status appearing in the dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WFcz6fih7vHJbndfhaz4E