### PR TITLE
Give each lock its own logger

### DIFF
--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -38,6 +38,7 @@ from aiohttp import ClientResponse, ClientSession
 from homeassistant.components.application_credentials import AuthImplementation
 from homeassistant.helpers import config_entry_oauth2_flow
 
+from .const import get_device_logger
 from .models import (
     AddPasscodeConfig,
     Card,
@@ -124,15 +125,28 @@ class TTLockApi:
         kwargs["date"] = str(round(time.time() * 1000))
         return kwargs
 
-    async def _parse_resp(self, resp: ClientResponse, log_id: str) -> Mapping[str, Any]:
+    def _logger_for(self, kwargs: Mapping[str, Any]) -> logging.Logger:
+        """Return the lock-scoped logger for a request, or the shared logger.
+
+        Requests carrying a `lockId` (almost everything except account-wide
+        enumeration endpoints like lock/list) log through that lock's own
+        child logger instead of the shared integration logger.
+        """
+        if (lock_id := kwargs.get("lockId")) is not None:
+            return get_device_logger(lock_id)
+        return _LOGGER
+
+    async def _parse_resp(
+        self, resp: ClientResponse, log_id: str, logger: logging.Logger
+    ) -> Mapping[str, Any]:
         if resp.status >= 400:
             body = await resp.text()
-            _LOGGER.debug(
+            logger.debug(
                 "[%s] Request failed: status=%s, body=%s", log_id, resp.status, body
             )
         else:
             body = await resp.json()
-            _LOGGER.debug(
+            logger.debug(
                 "[%s] Received response: status=%s: body=%s", log_id, resp.status, body
             )
 
@@ -140,7 +154,7 @@ class TTLockApi:
 
         res = cast(dict, await resp.json())
         if res.get("errcode", 0) != 0:
-            _LOGGER.debug("[%s] API returned: %s", log_id, res)
+            logger.debug("[%s] API returned: %s", log_id, res)
             raise RequestFailed(f"API returned: {res}")
 
         return cast(dict, await resp.json())
@@ -148,28 +162,30 @@ class TTLockApi:
     async def get(self, path: str, **kwargs: Any) -> Mapping[str, Any]:
         """Make GET request to the API with kwargs as query params."""
         log_id = token_hex(2)
+        logger = self._logger_for(kwargs)
 
         url = urljoin(self.BASE, path)
-        _LOGGER.debug("[%s] Sending request to %s with args=%s", log_id, url, kwargs)
+        logger.debug("[%s] Sending request to %s with args=%s", log_id, url, kwargs)
         resp = await self._web_session.get(
             url,
             params=await self._add_auth(**kwargs),
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
-        return await self._parse_resp(resp, log_id)
+        return await self._parse_resp(resp, log_id, logger)
 
     async def post(self, path: str, **kwargs: Any) -> Mapping[str, Any]:
         """Make GET request to the API with kwargs as query params."""
         log_id = token_hex(2)
+        logger = self._logger_for(kwargs)
 
         url = urljoin(self.BASE, path)
-        _LOGGER.debug("[%s] Sending request to %s with args=%s", log_id, url, kwargs)
+        logger.debug("[%s] Sending request to %s with args=%s", log_id, url, kwargs)
         resp = await self._web_session.post(
             url,
             params=await self._add_auth(),
             data=kwargs,
         )
-        return await self._parse_resp(resp, log_id)
+        return await self._parse_resp(resp, log_id, logger)
 
     async def get_locks(self) -> list[LockSummary]:
         """Enumerate all locks in the account (connectable and not)."""

--- a/custom_components/ttlock/const.py
+++ b/custom_components/ttlock/const.py
@@ -1,5 +1,7 @@
 """Constants for the TTLock integration."""
 
+import logging
+
 DOMAIN = "ttlock"
 TT_API = "api"
 TT_LOCKS = "locks"
@@ -10,6 +12,17 @@ CONF_WEBHOOK_URL = "webhook_url"
 CONF_WEBHOOK_STATUS = "webhook_status"
 
 SIGNAL_NEW_DATA = f"{DOMAIN}.data_received"
+
+
+def get_device_logger(lock_id: int) -> logging.Logger:
+    """Return the per-lock child logger for lock_id.
+
+    Named `<integration logger>.device.<lockId>` - a child of the shared
+    integration logger, so enabling the integration's existing top-level
+    debug logging still enables every lock's logger too (see
+    docs/adr/0001-per-lock-debug-capture-via-logger-hierarchy.md).
+    """
+    return logging.getLogger(__package__).getChild(f"device.{lock_id}")
 
 
 CONF_AUTO_UNLOCK = "auto_unlock"

--- a/custom_components/ttlock/webhook.py
+++ b/custom_components/ttlock/webhook.py
@@ -31,7 +31,13 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.network import NoURLAvailableError
 
-from .const import CONF_WEBHOOK_STATUS, CONF_WEBHOOK_URL, DOMAIN, SIGNAL_NEW_DATA
+from .const import (
+    CONF_WEBHOOK_STATUS,
+    CONF_WEBHOOK_URL,
+    DOMAIN,
+    SIGNAL_NEW_DATA,
+    get_device_logger,
+)
 from .models import WebhookEvent
 
 _LOGGER = logging.getLogger(__name__)
@@ -131,7 +137,12 @@ class WebhookHandler:
         try:
             # {'lockId': ['7252408'], 'notifyType': ['1'], 'records': ['[{"lockId":7252408,"electricQuantity":93,"serverDate":1680810180029,"recordTypeFromLock":17,"recordType":7,"success":1,"lockMac":"16:72:4C:CC:01:C4","keyboardPwd":"<digits>","lockDate":1680810186000,"username":"Jonas"}]'], 'admin': ['jonas@lemon.nz'], 'lockMac': ['16:72:4C:CC:01:C4']}
             if data := await request.post():
-                _LOGGER.debug("Got webhook data: %s", data)
+                logger = (
+                    get_device_logger(int(lock_id))  # ty: ignore[invalid-argument-type] - lockId is always a form field string, never a file upload
+                    if (lock_id := data.get("lockId"))
+                    else _LOGGER
+                )
+                logger.debug("Got webhook data: %s", data)
                 for raw_records in data.getall("records", []):
                     for record in json.loads(raw_records):  # ty: ignore[invalid-argument-type] - always a JSON string, never a file upload
                         async_dispatcher_send(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 """Test the TTLockApi REST client."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientResponseError
@@ -126,6 +127,64 @@ class TestGetAndPost:
 
         with pytest.raises(RequestFailed):
             await ttlock_api.get("lock/detail", lockId=1)
+
+
+class TestPerLockLogging:
+    async def test_debug_on_one_lock_logger_does_not_capture_another_locks_records(
+        self, ttlock_api: TTLockApi, mocker: AiohttpClientMocker, caplog
+    ):
+        # pytest_homeassistant_custom_component forces the root logger to
+        # DEBUG for every test, so lock 2's logger needs an explicit level
+        # above DEBUG here to simulate its normal, un-enabled default -
+        # otherwise every logger would already capture everything and this
+        # test couldn't tell isolation from coincidence.
+        mocker.get(f"{BASE}lock/detail", json={"errcode": 0})
+        mocker.get(f"{BASE}lock/queryOpenState", json={"errcode": 0})
+        # order matters: caplog's set_level shares one handler whose level is
+        # overwritten by each call, so the DEBUG call must come last to keep
+        # the handler itself open to DEBUG records - device.2 is still
+        # excluded because its *logger* (not the shared handler) stays at
+        # WARNING.
+        caplog.set_level(logging.WARNING, logger="custom_components.ttlock.device.2")
+        caplog.set_level(logging.DEBUG, logger="custom_components.ttlock.device.1")
+
+        await ttlock_api.get("lock/detail", lockId=1)
+        await ttlock_api.get("lock/queryOpenState", lockId=2)
+
+        assert any(
+            record.name == "custom_components.ttlock.device.1"
+            for record in caplog.records
+        )
+        assert not any(
+            record.name == "custom_components.ttlock.device.2"
+            for record in caplog.records
+        )
+
+    async def test_request_scoped_to_lock_id_logs_via_that_locks_child_logger(
+        self, ttlock_api: TTLockApi, mocker: AiohttpClientMocker, caplog
+    ):
+        mocker.get(f"{BASE}lock/detail", json={"errcode": 0})
+        caplog.set_level(logging.DEBUG, logger="custom_components.ttlock.device.42")
+
+        await ttlock_api.get("lock/detail", lockId=42)
+
+        assert any(
+            "Sending request" in record.message
+            and record.name == "custom_components.ttlock.device.42"
+            for record in caplog.records
+        )
+
+    async def test_request_without_lock_id_logs_via_shared_logger(
+        self, ttlock_api: TTLockApi, mocker: AiohttpClientMocker, caplog
+    ):
+        mocker.get(f"{BASE}lock/list", json={"list": []})
+        caplog.set_level(logging.DEBUG, logger="custom_components.ttlock.api")
+
+        await ttlock_api.get_locks()
+
+        assert any(
+            record.name == "custom_components.ttlock.api" for record in caplog.records
+        )
 
 
 class TestGetLocks:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,6 +1,7 @@
 """Test the TTLock webhook handler."""
 
 import json
+import logging
 from typing import cast
 from unittest.mock import ANY, AsyncMock, patch
 
@@ -144,6 +145,50 @@ class TestHandleWebhook:
             await handler.handle_webhook(hass, "wh-id", _request(MultiDict()))
 
         mock_dismiss.assert_not_called()
+
+
+class TestPerLockLogging:
+    async def test_debug_on_one_locks_logger_does_not_capture_anothers_webhook_data(
+        self, hass: HomeAssistant, handler: WebhookHandler, caplog
+    ):
+        # See the equivalent test in tests/test_api.py for why the WARNING
+        # call must come first: caplog.set_level shares one handler whose
+        # level is overwritten by each call.
+        caplog.set_level(logging.WARNING, logger="custom_components.ttlock.device.2")
+        caplog.set_level(
+            logging.DEBUG, logger="custom_components.ttlock.device.7252408"
+        )
+
+        request = _request(
+            MultiDict(
+                {"lockId": "7252408", "records": json.dumps([WEBHOOK_LOCK_10AM_UTC])}
+            )
+        )
+        await handler.handle_webhook(hass, "wh-id", request)
+        await hass.async_block_till_done()
+
+        assert any(
+            record.name == "custom_components.ttlock.device.7252408"
+            for record in caplog.records
+        )
+        assert not any(
+            record.name == "custom_components.ttlock.device.2"
+            for record in caplog.records
+        )
+
+    async def test_webhook_data_without_lock_id_logs_via_shared_logger(
+        self, hass: HomeAssistant, handler: WebhookHandler, caplog
+    ):
+        caplog.set_level(logging.DEBUG, logger="custom_components.ttlock.webhook")
+
+        request = _request(MultiDict({"records": json.dumps([WEBHOOK_LOCK_10AM_UTC])}))
+        await handler.handle_webhook(hass, "wh-id", request)
+        await hass.async_block_till_done()
+
+        assert any(
+            record.name == "custom_components.ttlock.webhook"
+            for record in caplog.records
+        )
 
 
 class TestSetup:


### PR DESCRIPTION
## Summary

- Each lock now gets its own child logger, named `custom_components.ttlock.device.<lockId>` (a child of the shared integration logger), via a new `get_device_logger()` helper in `const.py`.
- `TTLockApi.get`/`.post` (and the debug-level request/response/errcode logging in `_parse_resp`) now route through the relevant lock's logger whenever a call carries a `lockId`; calls that don't (e.g. `lock/list`, `gateway/list`) keep using the shared integration logger.
- The webhook handler routes inbound event logging through the same lock's logger, keyed by the `lockId` field in the inbound payload.
- Because these are real child loggers with no level of their own, enabling the integration's existing top-level debug logging still cascades to every lock's logger, unchanged.

This is the "per-lock child loggers" slice of #283 - laying the foundation for the later per-lock debug capture work (ring-buffer handler, diagnostics surfacing, capture button), none of which is in scope here. See `docs/adr/0001-per-lock-debug-capture-via-logger-hierarchy.md` for the design rationale.

Closes #287

## Test plan

- [x] `script/check` passes (lint, type-check, full test suite)
- [x] New tests in `tests/test_api.py::TestPerLockLogging` and `tests/test_webhook.py::TestPerLockLogging` confirm setting one lock's logger to debug captures only that lock's records, not another lock's
- [x] Reviewed with `/code-review` against `develop` (Standards + Spec axes) - no findings on either axis

🤖 Generated with [Claude Code](https://claude.com/claude-code)