### PR TITLE
Add per-device diagnostics for locks

### DIFF
--- a/custom_components/ttlock/diagnostics.py
+++ b/custom_components/ttlock/diagnostics.py
@@ -9,8 +9,10 @@ from typing import Any
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN, TT_GATEWAYS, TT_LOCKS
+from .coordinator import LockUpdateCoordinator
 from .models import BaseModel
 
 TO_REDACT = {
@@ -38,6 +40,24 @@ def build_diagnostics_dict(d: dict) -> dict[str, Any]:
     return d
 
 
+def _lock_diagnostics(coordinator: LockUpdateCoordinator) -> dict[str, Any]:
+    """Build the diagnostics dict for a single lock, shared by both dump surfaces."""
+    return build_diagnostics_dict(coordinator.as_dict())
+
+
+def _find_lock_coordinator(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
+) -> LockUpdateCoordinator | None:
+    """Find the lock coordinator matching a device's TTLock MAC identifier."""
+    macs = {
+        identifier[1] for identifier in device.identifiers if identifier[0] == DOMAIN
+    }
+    for coordinator in hass.data[DOMAIN][config_entry.entry_id][TT_LOCKS]:
+        if coordinator.data.mac in macs:
+            return coordinator
+    return None
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict[str, Any]:
@@ -47,10 +67,22 @@ async def async_get_config_entry_diagnostics(
         {
             "config_entry": config_entry.as_dict(),
             "locks": [
-                build_diagnostics_dict(coordinator.as_dict())
+                _lock_diagnostics(coordinator)
                 for coordinator in hass.data[DOMAIN][config_entry.entry_id][TT_LOCKS]
             ],
             "gateways": hass.data[DOMAIN][config_entry.entry_id][TT_GATEWAYS].as_dict(),
         },
         TO_REDACT,
     )
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a single lock device."""
+
+    coordinator = _find_lock_coordinator(hass, config_entry, device)
+    if coordinator is None:
+        return {}
+
+    return async_redact_data(_lock_diagnostics(coordinator), TO_REDACT)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,16 +1,17 @@
 """Test ttlock diagnostics."""
 
 from custom_components.ttlock.const import DOMAIN
-from custom_components.ttlock.diagnostics import async_get_config_entry_diagnostics
+from custom_components.ttlock.diagnostics import (
+    async_get_config_entry_diagnostics,
+    async_get_device_diagnostics,
+)
 from custom_components.ttlock.models import Gateway, LockSummary
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 
-async def test_diagnostics_includes_connectable_and_health(
-    hass: HomeAssistant, component_setup, mock_api_responses, monkeypatch
-):
-    """Diagnostics surface connectable and last_update_success for troubleshooting."""
-    mock_api_responses("default")
+def _mock_connectable_and_gatewayless_lock(monkeypatch) -> None:
+    """Patch get_locks to return one connectable lock and one without a gateway."""
 
     async def mock_get_locks(*args, **kwargs):
         return [
@@ -31,6 +32,14 @@ async def test_diagnostics_includes_connectable_and_health(
     monkeypatch.setattr(
         "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
     )
+
+
+async def test_diagnostics_includes_connectable_and_health(
+    hass: HomeAssistant, component_setup, mock_api_responses, monkeypatch
+):
+    """Diagnostics surface connectable and last_update_success for troubleshooting."""
+    mock_api_responses("default")
+    _mock_connectable_and_gatewayless_lock(monkeypatch)
 
     await component_setup()
 
@@ -110,3 +119,34 @@ async def test_diagnostics_includes_raw_connectivity_fields_and_gateway_status(
     gateways = diagnostics["gateways"]
     assert gateways[0]["name"] == "Test Gateway"
     assert gateways[0]["is_online"] is True
+
+
+async def test_device_diagnostics_matches_config_entry_lock_entry(
+    hass: HomeAssistant, component_setup, mock_api_responses, monkeypatch
+):
+    """Device-scoped diagnostics return only the requested lock, matching the config-entry dump."""
+    mock_api_responses("default")
+    _mock_connectable_and_gatewayless_lock(monkeypatch)
+
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:00:00:00:00:02")}
+    )
+    assert device is not None
+
+    device_diagnostics = await async_get_device_diagnostics(hass, entry, device)
+    config_entry_diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    expected = next(
+        lock
+        for lock in config_entry_diagnostics["locks"]
+        if lock["unique_id"] == f"{DOMAIN}-2"
+    )
+    assert device_diagnostics == expected
+    assert {lock["unique_id"] for lock in config_entry_diagnostics["locks"]} == {
+        f"{DOMAIN}-2",
+        f"{DOMAIN}-7252408",
+    }


### PR DESCRIPTION
## Summary
- Adds a device-scoped `async_get_device_diagnostics` handler for lock devices, matching the requested `DeviceEntry` to its `LockUpdateCoordinator` by MAC identifier.
- Extracts a shared `_lock_diagnostics()` helper used by both the config-entry-level dump and the device-level dump, so the two surfaces can't drift apart.
- Adds a test confirming the device-scoped handler returns only the requested lock's data, matching that lock's entry in the config-entry dump exactly.

Closes #288

## Test plan
- [x] `script/check` (lint, type-check, full test suite) passes — 197 tests
- [x] New test `test_device_diagnostics_matches_config_entry_lock_entry` verifies device diagnostics match the config-entry dump's per-lock entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMxkRYza1uvyukbm2RDNZz