### PR TITLE
Capture and surface a lock's raw traffic in diagnostics

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -11,7 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
 
 from .api import TTLockApi
-from .const import DOMAIN, TT_API, TT_GATEWAYS, TT_LOCKS
+from .capture import DebugCaptureHandler
+from .const import DOMAIN, TT_API, TT_CAPTURE, TT_GATEWAYS, TT_LOCKS
 from .coordinator import GatewaysUpdateCoordinator, LockUpdateCoordinator
 from .services import Services
 from .webhook import WebhookHandler
@@ -24,6 +25,12 @@ PLATFORMS: list[Platform] = [
 ]
 
 DETAIL_FILL_CONCURRENCY = 3
+
+# Not an entry_id (those are opaque hex strings from HA's entry-id
+# generator) - marks the one DebugCaptureHandler shared by every loaded
+# config entry, so a second TTLock account doesn't get a second handler
+# attached to the same shared logger.
+_CAPTURE_HANDLER_KEY = "_capture_handler"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,10 +69,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
     client = TTLockApi(aiohttp_client.async_get_clientsession(hass), session)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {TT_API: client}
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    capture_handler = domain_data.get(_CAPTURE_HANDLER_KEY)
+    if capture_handler is None:
+        capture_handler = DebugCaptureHandler()
+        logging.getLogger(__package__).addHandler(capture_handler)
+        domain_data[_CAPTURE_HANDLER_KEY] = capture_handler
+
+    domain_data[entry.entry_id] = {
+        TT_API: client,
+        TT_CAPTURE: capture_handler,
+    }
 
     locks = [
-        LockUpdateCoordinator(hass, entry, client, summary)
+        LockUpdateCoordinator(hass, entry, client, summary, capture_handler)
         for summary in await client.get_locks()
     ]
     hass.data[DOMAIN][entry.entry_id][TT_LOCKS] = locks
@@ -104,6 +121,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        domain_data = hass.data[DOMAIN]
+        domain_data.pop(entry.entry_id)
+
+        # last entry gone - detach the shared capture handler too
+        if not any(key != _CAPTURE_HANDLER_KEY for key in domain_data):
+            handler = domain_data.pop(_CAPTURE_HANDLER_KEY)
+            logging.getLogger(__package__).removeHandler(handler)
 
     return unload_ok

--- a/custom_components/ttlock/capture.py
+++ b/custom_components/ttlock/capture.py
@@ -1,0 +1,109 @@
+"""Buffers a lock's raw TTLock traffic for diagnostics.
+
+Per docs/adr/0001-per-lock-debug-capture-via-logger-hierarchy.md, debug
+capture isn't a bespoke opt-in system - it rides HA's own logger hierarchy.
+A single DebugCaptureHandler is attached to the integration's shared base
+logger once per Home Assistant instance - shared across every loaded config
+entry, not one handler per entry (see __init__.py's _CAPTURE_HANDLER_KEY).
+Because Python only calls a logger's debug() when that logger - or an
+inherited ancestor level - is actually enabled for DEBUG, this handler only
+ever buffers something once a lock's specific child logger
+(get_device_logger) has been raised to DEBUG, whether via a future "start
+capture" button (#290) or HA's own Configure Logger UI. There's no separate
+"capture active" flag anywhere in this module's own state; diagnostics_for
+derives it by checking that lock's logger directly.
+
+Redaction happens here, once, against each record's original *args* (still
+a real dict/list at this point) rather than its rendered message string -
+that's what makes field-level redaction possible instead of regex-scrubbing
+text. emit() never mutates the LogRecord it's given, so HA's other log
+handlers - the actual live log output - still see the record exactly as
+emitted, unredacted.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+from datetime import datetime
+import logging
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.util import dt as dt_util
+
+from .const import DEVICE_LOGGER_PREFIX, TO_REDACT
+
+MAX_RECORDS_PER_LOCK = 200
+
+
+@dataclass
+class CapturedRecord:
+    """A single redacted log record captured for one lock."""
+
+    timestamp: datetime
+    level: str
+    message: str
+
+
+def _redact_arg(value: object) -> object:
+    """Redact a single logging arg if it's a dict/list, otherwise pass it through."""
+    if isinstance(value, (dict, list)):
+        return async_redact_data(value, TO_REDACT)
+    return value
+
+
+class DebugCaptureHandler(logging.Handler):
+    """Buckets each lock's debug records into its own bounded ring buffer."""
+
+    def __init__(self, maxlen: int = MAX_RECORDS_PER_LOCK) -> None:
+        """Initialize with an empty per-lock buffer map."""
+        super().__init__()
+        self._maxlen = maxlen
+        self._buffers: dict[str, deque[CapturedRecord]] = {}
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Redact and buffer a record, but only if it came from a lock's own logger."""
+        if not record.name.startswith(DEVICE_LOGGER_PREFIX):
+            return
+
+        args = record.args
+        redacted_args: object
+        if isinstance(args, tuple):
+            redacted_args = tuple(_redact_arg(arg) for arg in args)
+        else:
+            redacted_args = _redact_arg(args)
+
+        message = str(record.msg) % redacted_args if redacted_args else str(record.msg)
+
+        buffer = self._buffers.setdefault(record.name, deque(maxlen=self._maxlen))
+        buffer.append(
+            CapturedRecord(
+                timestamp=dt_util.utc_from_timestamp(record.created),
+                level=record.levelname,
+                message=message,
+            )
+        )
+
+    def snapshot_for(self, logger_name: str) -> list[CapturedRecord]:
+        """Return a lock's captured records, oldest first."""
+        return list(self._buffers.get(logger_name, ()))
+
+    def diagnostics_for(self, logger: logging.Logger) -> dict[str, Any]:
+        """Build the diagnostics-facing capture summary for one lock's logger.
+
+        `active` is derived live from the logger's own effective level
+        rather than tracked separately, so it's always in sync with
+        whatever raised it (a future capture button, or HA's Configure
+        Logger UI) - see the module docstring.
+        """
+        records = self.snapshot_for(logger.name)
+        return {
+            "active": logger.isEnabledFor(logging.DEBUG),
+            "window": (
+                {"start": records[0].timestamp, "end": records[-1].timestamp}
+                if records
+                else None
+            ),
+            "records": [asdict(record) for record in records],
+        }

--- a/custom_components/ttlock/const.py
+++ b/custom_components/ttlock/const.py
@@ -6,12 +6,27 @@ DOMAIN = "ttlock"
 TT_API = "api"
 TT_LOCKS = "locks"
 TT_GATEWAYS = "gateways"
+TT_CAPTURE = "capture"
 
 OAUTH2_TOKEN = "https://euapi.ttlock.com/oauth2/token"
 CONF_WEBHOOK_URL = "webhook_url"
 CONF_WEBHOOK_STATUS = "webhook_status"
 
 SIGNAL_NEW_DATA = f"{DOMAIN}.data_received"
+
+DEVICE_LOGGER_PREFIX = f"{__package__}.device."
+
+TO_REDACT = {
+    "token",
+    "lockKey",
+    "aesKeyStr",
+    "adminPwd",
+    "deletePwd",
+    "noKeyPwd",
+    "lockData",
+    "webhook_id",
+    "webhook_url",
+}
 
 
 def get_device_logger(lock_id: int) -> logging.Logger:
@@ -22,7 +37,7 @@ def get_device_logger(lock_id: int) -> logging.Logger:
     debug logging still enables every lock's logger too (see
     docs/adr/0001-per-lock-debug-capture-via-logger-hierarchy.md).
     """
-    return logging.getLogger(__package__).getChild(f"device.{lock_id}")
+    return logging.getLogger(f"{DEVICE_LOGGER_PREFIX}{lock_id}")
 
 
 CONF_AUTO_UNLOCK = "auto_unlock"

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -28,7 +28,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from .api import TTLockApi
-from .const import DOMAIN, SIGNAL_NEW_DATA, TT_GATEWAYS, TT_LOCKS
+from .capture import DebugCaptureHandler
+from .const import DOMAIN, SIGNAL_NEW_DATA, TT_GATEWAYS, TT_LOCKS, get_device_logger
 from .models import (
     Features,
     Gateway,
@@ -167,6 +168,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         config_entry: ConfigEntry,
         api: TTLockApi,
         summary: LockSummary,
+        capture: DebugCaptureHandler,
     ) -> None:
         """Initialize the update co-ordinator for a single lock."""
         self.api = api
@@ -174,6 +176,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         self.connectable = summary.connectable
         self.has_gateway = summary.hasGateway
         self.feature_value = summary.featureValue
+        self._capture = capture
 
         super().__init__(
             hass,
@@ -372,6 +375,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
                 for entity in self.entities
                 if (state := self.hass.states.get(entity.entity_id)) is not None
             ],
+            "debug_capture": self._capture.diagnostics_for(
+                get_device_logger(self.lock_id)
+            ),
         }
 
     async def lock(self) -> None:

--- a/custom_components/ttlock/diagnostics.py
+++ b/custom_components/ttlock/diagnostics.py
@@ -11,21 +11,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import DOMAIN, TT_GATEWAYS, TT_LOCKS
+from .const import DOMAIN, TO_REDACT, TT_GATEWAYS, TT_LOCKS
 from .coordinator import LockUpdateCoordinator
 from .models import BaseModel
-
-TO_REDACT = {
-    "token",
-    "lockKey",
-    "aesKeyStr",
-    "adminPwd",
-    "deletePwd",
-    "noKeyPwd",
-    "lockData",
-    "webhook_id",
-    "webhook_url",
-}
 
 
 def build_diagnostics_dict(d: dict) -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ttlock.api import TTLockApi
+from custom_components.ttlock.capture import DebugCaptureHandler
 from custom_components.ttlock.const import DOMAIN, TT_LOCKS
 from custom_components.ttlock.coordinator import LockUpdateCoordinator
 from custom_components.ttlock.models import (
@@ -112,7 +113,9 @@ async def coordinator(hass, api):
     summary = LockSummary(
         lockId=7252408, lockAlias="Test Lock", lockMac="00:00:00:00:00:00", hasGateway=1
     )
-    return LockUpdateCoordinator(hass, config_entry, api, summary)
+    return LockUpdateCoordinator(
+        hass, config_entry, api, summary, DebugCaptureHandler()
+    )
 
 
 class MockApiData(NamedTuple):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ttlock.api import RequestFailed
+from custom_components.ttlock.capture import DebugCaptureHandler
 from custom_components.ttlock.const import DOMAIN
 from custom_components.ttlock.coordinator import (
     GatewaysUpdateCoordinator,
@@ -266,7 +267,9 @@ class TestLockUpdateCoordinator:
                 lockMac="00:00:00:00:00:01",
                 hasGateway=0,
             )
-            coordinator = LockUpdateCoordinator(hass, config_entry, api, summary)
+            coordinator = LockUpdateCoordinator(
+                hass, config_entry, api, summary, DebugCaptureHandler()
+            )
 
             assert coordinator.connectable is False
             assert coordinator.update_interval is None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,6 +1,16 @@
 """Test ttlock diagnostics."""
 
-from custom_components.ttlock.const import DOMAIN
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
+
+from custom_components.ttlock.api import TTLockApi
+from custom_components.ttlock.capture import DebugCaptureHandler
+from custom_components.ttlock.const import DOMAIN, TT_GATEWAYS, TT_LOCKS
+from custom_components.ttlock.coordinator import LockUpdateCoordinator
 from custom_components.ttlock.diagnostics import (
     async_get_config_entry_diagnostics,
     async_get_device_diagnostics,
@@ -8,6 +18,10 @@ from custom_components.ttlock.diagnostics import (
 from custom_components.ttlock.models import Gateway, LockSummary
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+
+from .const import BASIC_LOCK_DETAILS, LOCK_STATE_UNLOCKED, PASSAGE_MODE_6_TO_6_7_DAYS
+
+API_BASE = "https://euapi.ttlock.com/v3/"
 
 
 def _mock_connectable_and_gatewayless_lock(monkeypatch) -> None:
@@ -150,3 +164,90 @@ async def test_device_diagnostics_matches_config_entry_lock_entry(
         f"{DOMAIN}-2",
         f"{DOMAIN}-7252408",
     }
+
+
+async def test_debug_capture_appears_redacted_in_diagnostics(
+    hass: HomeAssistant, caplog
+):
+    """A lock's captured debug traffic is redacted in diagnostics, but not in HA's live logs.
+
+    Deliberately bypasses the `mock_api_responses` fixture, which stubs out
+    TTLockApi's methods entirely and so never exercises the request/response
+    debug logging this test is about - instead it mocks at the HTTP layer
+    (like test_api.py) so the real TTLockApi.get/_parse_resp logging runs.
+    """
+    device_logger_name = "custom_components.ttlock.device.7252408"
+    caplog.set_level(logging.DEBUG, logger=device_logger_name)
+
+    mocker = AiohttpClientMocker()
+    mocker.get(f"{API_BASE}lock/detail", json=BASIC_LOCK_DETAILS)
+    mocker.get(f"{API_BASE}lock/queryOpenState", json=LOCK_STATE_UNLOCKED)
+    mocker.get(f"{API_BASE}lock/getPassageModeConfig", json=PASSAGE_MODE_6_TO_6_7_DAYS)
+
+    oauth_session = MagicMock()
+    oauth_session.valid_token = True
+    oauth_session.token = {"access_token": "mock-access-token"}
+    oauth_session.implementation.client_id = "mock-client-id"
+    oauth_session.async_ensure_token_valid = AsyncMock()
+
+    session = mocker.create_session(None)
+    capture_handler = DebugCaptureHandler()
+    package_logger = logging.getLogger("custom_components.ttlock")
+    package_logger.addHandler(capture_handler)
+
+    try:
+        api = TTLockApi(session, oauth_session)
+        config_entry = MockConfigEntry(domain=DOMAIN)
+        config_entry.add_to_hass(hass)
+        summary = LockSummary(
+            lockId=7252408,
+            lockAlias="Front Door",
+            lockMac="16:72:4C:CC:01:C4",
+            hasGateway=1,
+        )
+        coordinator = LockUpdateCoordinator(
+            hass, config_entry, api, summary, capture_handler
+        )
+        await coordinator.async_refresh()
+
+        hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {
+            TT_LOCKS: [coordinator],
+            TT_GATEWAYS: SimpleNamespace(as_dict=list),
+        }
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id, **coordinator.device_info
+        )
+
+        diagnostics = await async_get_config_entry_diagnostics(hass, config_entry)
+        device_diagnostics = await async_get_device_diagnostics(
+            hass, config_entry, device
+        )
+    finally:
+        package_logger.removeHandler(capture_handler)
+        await session.close()
+
+    capture = diagnostics["locks"][0]["debug_capture"]
+    assert capture["active"] is True
+    assert capture["window"] is not None
+
+    # Per-device diagnostics carry the same capture content, not just the
+    # config-entry-level dump - both surfaces are required.
+    assert device_diagnostics["debug_capture"] == capture
+
+    captured_messages = [record["message"] for record in capture["records"]]
+    assert any("Received response" in message for message in captured_messages)
+
+    # lockKey is a known-sensitive field present in the real lock/detail response body.
+    sensitive_value = BASIC_LOCK_DETAILS["lockKey"]
+    assert not any(sensitive_value in message for message in captured_messages)
+    assert any("**REDACTED**" in message for message in captured_messages)
+
+    # HA's own live log output for the same records is unaffected by redaction.
+    live_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == device_logger_name
+    ]
+    assert any(sensitive_value in message for message in live_messages)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,11 +1,21 @@
 """Test ttlock setup process."""
 
+import logging
+from time import time
 from unittest.mock import patch
 
-from custom_components.ttlock.const import DOMAIN, TT_LOCKS
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ttlock.capture import DebugCaptureHandler
+from custom_components.ttlock.const import DOMAIN, TT_CAPTURE, TT_LOCKS
 from custom_components.ttlock.models import LockSummary
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers.network import NoURLAvailableError
+from homeassistant.setup import async_setup_component
 
 
 async def test_setup_unload_and_reload_entry(hass, component_setup, mock_api_responses):
@@ -18,8 +28,78 @@ async def test_setup_unload_and_reload_entry(hass, component_setup, mock_api_res
     entry = entries[0]
     assert entry.state is ConfigEntryState.LOADED
 
+    package_logger = logging.getLogger("custom_components.ttlock")
+    assert any(
+        isinstance(handler, DebugCaptureHandler) for handler in package_logger.handlers
+    )
+
     assert await hass.config_entries.async_unload(entry.entry_id)
     assert entry.state == ConfigEntryState.NOT_LOADED
+
+    # the last entry unloading must detach the shared debug-capture handler
+    assert not any(
+        isinstance(handler, DebugCaptureHandler) for handler in package_logger.handlers
+    )
+
+
+async def test_capture_handler_is_shared_across_config_entries(
+    hass, mock_api_responses
+):
+    """A single DebugCaptureHandler is attached once, even with two TTLock accounts."""
+    mock_api_responses("default")
+
+    assert await async_setup_component(hass, "application_credentials", {})
+    await async_import_client_credential(
+        hass, DOMAIN, ClientCredential("client-id", "client-secret"), "mocked"
+    )
+
+    def _new_entry() -> MockConfigEntry:
+        return MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "auth_implementation": "mocked",
+                "token": {
+                    "refresh_token": "mock-refresh-token",
+                    "access_token": "mock-access-token",
+                    "type": "Bearer",
+                    "expires_in": 60,
+                    "expires_at": time() + 1000,
+                    "scope": "",
+                },
+            },
+        )
+
+    # entry_b must not be added until entry_a's setup has finished: adding
+    # both before any setup call would let HA's component-level bootstrap
+    # (triggered by entry_a's setup, the domain's first) auto-forward-setup
+    # entry_b too, racing the explicit call below.
+    entry_a = _new_entry()
+    entry_a.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry_a.entry_id)
+
+    entry_b = _new_entry()
+    entry_b.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry_b.entry_id)
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    package_logger = logging.getLogger("custom_components.ttlock")
+    handlers = [
+        handler
+        for handler in package_logger.handlers
+        if isinstance(handler, DebugCaptureHandler)
+    ]
+    assert len(handlers) == 1
+    assert (
+        hass.data[DOMAIN][entry_a.entry_id][TT_CAPTURE]
+        is hass.data[DOMAIN][entry_b.entry_id][TT_CAPTURE]
+    )
+
+    assert await hass.config_entries.async_unload(entry_a.entry_id)
+    assert any(isinstance(h, DebugCaptureHandler) for h in package_logger.handlers)
+
+    assert await hass.config_entries.async_unload(entry_b.entry_id)
+    assert not any(isinstance(h, DebugCaptureHandler) for h in package_logger.handlers)
 
 
 @patch(


### PR DESCRIPTION
## Summary
- Adds `DebugCaptureHandler`, a single `logging.Handler` attached once per HA instance (shared across all loaded config entries) that buckets records by device-logger name into a bounded per-lock ring buffer (200 entries, oldest evicted first)
- Buffered records are redacted using the same `TO_REDACT` rules as the rest of diagnostics, applied to each record's structured `args` rather than the rendered string - HA's live log output for the same records is untouched
- Both config-entry and per-device diagnostics now include a `debug_capture` section per lock: whether capture is currently active (`logger.isEnabledFor(DEBUG)`), the buffer's time window, and the redacted records

Part of #283, implements #289. The "Start debug capture" button and its 30-minute auto-revert are out of scope here (#290).

## Test plan
- [x] `script/check` (ruff, `ty`, full pytest suite - 199 tests) passes
- [x] New test in `tests/test_diagnostics.py` enables a lock's logger to DEBUG via real HTTP-mocked `TTLockApi` calls, then asserts both config-entry and per-device diagnostics contain the expected redacted capture (with `lockKey` scrubbed), while `caplog`'s live records remain unredacted
- [x] New tests in `tests/test_init.py` confirm the handler is attached once and shared across multiple config entries (not duplicated per entry), and is correctly detached only when the last entry unloads