### PR TITLE
Add per-lock Start debug capture button

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -22,6 +22,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
+    Platform.BUTTON,
 ]
 
 DETAIL_FILL_CONCURRENCY = 3

--- a/custom_components/ttlock/button.py
+++ b/custom_components/ttlock/button.py
@@ -58,6 +58,12 @@ class StartDebugCapture(BaseLockEntity, ButtonEntity):
         """Fetch state from the device."""
         self._attr_name = f"{self.coordinator.data.name} Start Debug Capture"
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel any pending revert so it doesn't fire against a removed entity."""
+        if self._cancel_revert is not None:
+            self._cancel_revert()
+            self._cancel_revert = None
+
     async def async_press(self) -> None:
         """Raise this lock's logger to debug, and (re)start the revert window."""
         logger = get_device_logger(self.coordinator.lock_id)
@@ -67,9 +73,7 @@ class StartDebugCapture(BaseLockEntity, ButtonEntity):
         else:
             self._cancel_revert()
 
-        await self.hass.services.async_call(
-            LOGGER_DOMAIN, SERVICE_SET_LEVEL, {logger.name: "DEBUG"}, blocking=True
-        )
+        await self._async_set_level(logger.name, "DEBUG")
 
         self._cancel_revert = async_call_later(
             self.hass, CAPTURE_WINDOW, self._async_revert
@@ -82,6 +86,10 @@ class StartDebugCapture(BaseLockEntity, ButtonEntity):
         self._cancel_revert = None
         self._prior_level = None
 
+        await self._async_set_level(logger.name, level)
+
+    async def _async_set_level(self, logger_name: str, level: str) -> None:
+        """Call HA's built-in logger service to set one logger's level."""
         await self.hass.services.async_call(
-            LOGGER_DOMAIN, SERVICE_SET_LEVEL, {logger.name: level}, blocking=True
+            LOGGER_DOMAIN, SERVICE_SET_LEVEL, {logger_name: level}, blocking=True
         )

--- a/custom_components/ttlock/button.py
+++ b/custom_components/ttlock/button.py
@@ -1,0 +1,87 @@
+"""Button setup for TTLock diagnostics.
+
+`StartDebugCapture` is sugar over HA's own logger hierarchy (see
+docs/adr/0001-per-lock-debug-capture-via-logger-hierarchy.md) - it calls the
+stock `logger.set_level` service against a lock's own child logger, then
+schedules a callback to put the logger back where it found it after a fixed
+window. It's not a separate capture pathway; power users can achieve the same
+thing by hand via HA's Configure Logger UI.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.components.logger.const import (
+    DOMAIN as LOGGER_DOMAIN,
+    SERVICE_SET_LEVEL,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+
+from .const import get_device_logger
+from .coordinator import LockUpdateCoordinator, lock_coordinators
+from .entity import BaseLockEntity
+
+CAPTURE_WINDOW = timedelta(minutes=30)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up all the locks for the config entry."""
+
+    async_add_entities(
+        StartDebugCapture(coordinator) for coordinator in lock_coordinators(hass, entry)
+    )
+
+
+class StartDebugCapture(BaseLockEntity, ButtonEntity):
+    """Raises a lock's own logger to debug for a fixed window, then reverts it."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: LockUpdateCoordinator) -> None:
+        """Initialize with no capture in progress."""
+        super().__init__(coordinator)
+        self._prior_level: str | None = None
+        self._cancel_revert: CALLBACK_TYPE | None = None
+
+    def _update_from_coordinator(self) -> None:
+        """Fetch state from the device."""
+        self._attr_name = f"{self.coordinator.data.name} Start Debug Capture"
+
+    async def async_press(self) -> None:
+        """Raise this lock's logger to debug, and (re)start the revert window."""
+        logger = get_device_logger(self.coordinator.lock_id)
+
+        if self._cancel_revert is None:
+            self._prior_level = logging.getLevelName(logger.level)
+        else:
+            self._cancel_revert()
+
+        await self.hass.services.async_call(
+            LOGGER_DOMAIN, SERVICE_SET_LEVEL, {logger.name: "DEBUG"}, blocking=True
+        )
+
+        self._cancel_revert = async_call_later(
+            self.hass, CAPTURE_WINDOW, self._async_revert
+        )
+
+    async def _async_revert(self, _now: datetime) -> None:
+        """Put this lock's logger back to the level it was at before capture started."""
+        logger = get_device_logger(self.coordinator.lock_id)
+        level = self._prior_level or "NOTSET"
+        self._cancel_revert = None
+        self._prior_level = None
+
+        await self.hass.services.async_call(
+            LOGGER_DOMAIN, SERVICE_SET_LEVEL, {logger.name: level}, blocking=True
+        )

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -6,19 +6,43 @@ import logging
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.ttlock.const import get_device_logger
+from custom_components.ttlock.models import LockSummary
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
+# Deliberately not 7252408 (the shared "default" mock scenario's lock id, used
+# by most other tests) - this test drives the real HA `logger` component, and
+# HA's own logger machinery makes level changes on a given logger name sticky
+# process-wide across tests (see test_diagnostics.py's capture test, which
+# hardcodes 7252408 too). A dedicated id keeps this test's logger manipulation
+# from bleeding into unrelated tests.
+TEST_LOCK_ID = 555555
+
 
 async def test_press_starts_debug_capture_and_reverts_after_window(
-    hass: HomeAssistant, mock_api_responses, component_setup
+    hass: HomeAssistant, mock_api_responses, component_setup, monkeypatch
 ):
     """Pressing the button raises the lock's logger to debug, then reverts it after 30 minutes."""
     assert await async_setup_component(hass, "logger", {})
 
     mock_api_responses("default")
+
+    async def mock_get_locks(*args, **kwargs):
+        return [
+            LockSummary(
+                lockId=TEST_LOCK_ID,
+                lockAlias="Test Lock",
+                lockMac="00:00:00:00:00:99",
+                hasGateway=1,
+            )
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
+    )
+
     coordinator = await component_setup()
 
     device_logger = get_device_logger(coordinator.lock_id)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,45 @@
+"""Test the TTLock debug capture button."""
+
+from datetime import timedelta
+import logging
+
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.ttlock.const import get_device_logger
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+
+async def test_press_starts_debug_capture_and_reverts_after_window(
+    hass: HomeAssistant, mock_api_responses, component_setup
+):
+    """Pressing the button raises the lock's logger to debug, then reverts it after 30 minutes."""
+    assert await async_setup_component(hass, "logger", {})
+
+    mock_api_responses("default")
+    coordinator = await component_setup()
+
+    device_logger = get_device_logger(coordinator.lock_id)
+    device_logger.setLevel(logging.WARNING)
+
+    button_entity = next(
+        entity
+        for entity in coordinator.entities
+        if entity.entity_id.startswith("button.")
+    )
+
+    await hass.services.async_call(
+        "button",
+        "press",
+        {ATTR_ENTITY_ID: button_entity.entity_id},
+        blocking=True,
+    )
+
+    assert device_logger.level == logging.DEBUG
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=31))
+    await hass.async_block_till_done()
+
+    assert device_logger.level == logging.WARNING


### PR DESCRIPTION
## Summary
- Add a "Start debug capture" diagnostic button per lock (`custom_components/ttlock/button.py`), sugar over HA's own `logger.set_level` service against that lock's child logger (see `docs/adr/0001-per-lock-debug-capture-via-logger-hierarchy.md`)
- Pressing raises the lock's logger to debug and schedules an automatic revert to its prior level after a fixed 30-minute window; a repeat press within the window extends it rather than stacking timers
- Cancel the pending revert on entity removal so a reload/unload mid-window can't leave a stale callback mutating a removed entity's logger later

## Test plan
- [x] `script/check` (ruff format/lint, `ty`, full pytest suite)
- [x] New test presses the button via a service call, asserts the logger level changes, advances time past the window with `async_fire_time_changed`, and asserts the level reverts
- [x] Verified the new test doesn't cross-contaminate `test_diagnostics.py`'s capture test when run together (both use HA's real `logger` component against process-global logger objects)

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)