### PR TITLE
Deduplicate log-then-capture logic between api.py and webhook.py

### DIFF
--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -38,7 +38,7 @@ from aiohttp import ClientResponse, ClientSession
 from homeassistant.components.application_credentials import AuthImplementation
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .capture import LockTrafficCapture
+from .capture import LockTrafficCapture, log_and_capture
 from .const import get_device_logger
 from .models import (
     AddPasscodeConfig,
@@ -142,17 +142,8 @@ class TTLockApi:
     def _debug(
         self, logger: logging.Logger, lock_id: int | None, msg: str, *args: Any
     ) -> None:
-        """Emit a live debug log line and, for lock-scoped calls, always capture it too.
-
-        These are two independent consumers of the same event: `logger` is
-        the opt-in, live-log view (enabled via HA's Configure Logger UI);
-        `self._capture` is the always-on diagnostics ring buffer
-        (capture.py) - it doesn't care whether `logger` is actually enabled
-        for DEBUG.
-        """
-        logger.debug(msg, *args)
-        if lock_id is not None and self._capture is not None:
-            self._capture.capture(lock_id, "DEBUG", msg, *args)
+        """Emit a live debug log line and, for lock-scoped calls, always capture it too."""
+        log_and_capture(self._capture, logger, lock_id, msg, *args)
 
     async def _parse_resp(
         self,

--- a/custom_components/ttlock/capture.py
+++ b/custom_components/ttlock/capture.py
@@ -12,10 +12,11 @@ This is deliberately independent of get_device_logger's per-lock logger
 hierarchy (const.py): that hierarchy exists so a technical user can target
 one lock's *live* log output via HA's stock Configure Logger UI, and has no
 bearing on whether that lock's traffic ends up in this buffer. api.py and
-webhook.py call both at each capture site - logger.debug(...) for the
-live/opt-in view, LockTrafficCapture.capture(...) unconditionally for the
-always-on one - so enabling a lock's logger changes what you see live, never
-what ends up in diagnostics.
+webhook.py both call log_and_capture(...) at each capture site, which emits
+the live/opt-in logger.debug(...) and then, for lock-scoped calls, mirrors
+the same record into the always-on LockTrafficCapture.capture(...) - so
+enabling a lock's logger changes what you see live, never what ends up in
+diagnostics.
 
 Redaction happens here, once, against each call's original structured
 arguments (still real dicts/lists at this point) rather than a rendered
@@ -29,6 +30,7 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import asdict, dataclass
 from datetime import datetime
+import logging
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -93,3 +95,23 @@ class LockTrafficCapture:
             ),
             "records": [asdict(record) for record in records],
         }
+
+
+def log_and_capture(
+    capture: LockTrafficCapture | None,
+    logger: logging.Logger,
+    lock_id: int | None,
+    msg: str,
+    *args: Any,
+) -> None:
+    """Emit a live debug log line and, for lock-scoped calls, always capture it too.
+
+    Shared by api.py and webhook.py, the two call sites that observe raw
+    TTLock traffic - see this module's docstring. `logger` is the opt-in,
+    live-log view (enabled via HA's Configure Logger UI); `capture` is the
+    always-on diagnostics ring buffer - it doesn't care whether `logger` is
+    actually enabled for DEBUG.
+    """
+    logger.debug(msg, *args)
+    if lock_id is not None and capture is not None:
+        capture.capture(lock_id, "DEBUG", msg, *args)

--- a/custom_components/ttlock/webhook.py
+++ b/custom_components/ttlock/webhook.py
@@ -31,7 +31,7 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.network import NoURLAvailableError
 
-from .capture import LockTrafficCapture
+from .capture import LockTrafficCapture, log_and_capture
 from .const import (
     CONF_WEBHOOK_STATUS,
     CONF_WEBHOOK_URL,
@@ -150,11 +150,9 @@ class WebhookHandler:
                     else None
                 )
                 logger = get_device_logger(lock_id) if lock_id is not None else _LOGGER
-                logger.debug("Got webhook data: %s", data)
-                if lock_id is not None and self._capture is not None:
-                    self._capture.capture(
-                        lock_id, "DEBUG", "Got webhook data: %s", data
-                    )
+                log_and_capture(
+                    self._capture, logger, lock_id, "Got webhook data: %s", data
+                )
                 for raw_records in data.getall("records", []):
                     for record in json.loads(raw_records):  # ty: ignore[invalid-argument-type] - always a JSON string, never a file upload
                         async_dispatcher_send(


### PR DESCRIPTION
## Summary
- Extracts the "log to the given logger, then mirror into `LockTrafficCapture` for lock-scoped calls" pattern from `api.py`'s `_debug()` and `webhook.py`'s `handle_webhook` into one shared `log_and_capture()` helper in `capture.py`
- `api.py`'s `_debug()` now delegates to `log_and_capture`; `webhook.py` calls it directly at its single call site
- Pure refactor — verified live log output and capture buffer content are byte-for-byte identical to before

Closes #302

## Test plan
- [x] `script/check` passes (ruff, ty, full test suite — 203 passed)
- [x] Two-axis code review (Standards + Spec) both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)