### PR TITLE
Point issue template at per-device diagnostics, not manual debug logging

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -6,7 +6,14 @@ labels: ""
 assignees: jbergler
 ---
 
-<!--- Bug reports which do not follow this template will be closed -->
+<!---
+Bug reports which do not follow this template will be closed.
+
+Please keep every heading below (the lines starting with ## or ###) exactly
+as they are — only replace the placeholder text underneath each one. This
+issue is checked automatically against these headings; removing one (even
+if you've answered the question) will get the issue auto-closed.
+-->
 
 ## Describe the bug
 
@@ -29,10 +36,10 @@ A clear and concise description of what you expected to happen.
 
 <!---
 Note: if this information is not provided, the issue will likely be closed without investigation as I am unable to make progress.
-Documentation for how to gather this information is found at https://www.home-assistant.io/docs/configuration/troubleshooting/#enabling-debug-logging
 -->
 
 Please provide:
 
-- Debug logs reproducing the issue. For most issues, it is required to enable debug logging, and reload the extension so we capture the required information.
-- The diagnostic info for ttlock.
+- If this bug is about a specific lock: that lock's diagnostics. Go to the lock's device page (Settings → Devices & services → TTLock → click the lock) and use the three-dot menu → **Download diagnostics**. This automatically includes that lock's recent raw traffic — you do **not** need to enable debug logging first.
+- If this bug isn't tied to one lock (e.g. setup, login, or config flow problems), download the whole integration's diagnostics instead: Settings → Devices & services → TTLock → the three-dot menu on the integration card → **Download diagnostics**.
+- Only if the download above doesn't show the traffic around when the bug happened (for example, Home Assistant has restarted since): enable debug logging, reproduce the issue, and attach the resulting logs. See https://www.home-assistant.io/docs/configuration/troubleshooting/#enabling-debug-logging.

--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -13,5 +13,5 @@ jobs:
         uses: ergo720/auto-close-issues@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-close-message: "@${issue.user.login}: hello! :wave:\n\nThis issue is being automatically closed because it does not follow the issue template."
+          issue-close-message: "@${issue.user.login}: hello! :wave:\n\nThis issue is being automatically closed because it does not follow the [issue template](https://github.com/jbergler/hass-ttlock/blob/develop/.github/ISSUE_TEMPLATE/issue.md) — in particular, please include a lock's diagnostics download (see **Required information** in the template). Edit this issue to add the missing sections and it will reopen automatically."
           closed-issues-label: "invalid"


### PR DESCRIPTION
## Summary
- Update the issue template's "Required information" to lead reporters to the new per-device diagnostics download (carries a lock's recent raw traffic automatically, per #283), falling back to the whole-integration dump for non-lock-specific bugs and to manual debug logging only when the capture buffer missed the relevant window
- Warn reporters not to delete the template's `##`/`###` headings — the janitor's `auto-close-issues` action matches on them literally, so a reporter who deletes one while answering gets bounced for no real reason
- Point the janitor's auto-close message at the template and clarify that editing the issue (not opening a new one) reopens it

This is the "update the issue template / reporter-facing triage instructions" follow-up that #283 explicitly flagged as out of scope for that epic but a natural next step, now that all of #283's diagnostics/capture work has shipped.

Closes #283

## Test plan
- [x] `script/check` (ruff, codespell, ty — no Python files touched, so lint/type-check were no-ops; markdown/yaml only)
- [ ] Manually confirm a new issue opened against this template still passes the janitor's template check (headings unchanged from before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiJJmkqfPPUHMPgMdiLR56