### PR TITLE
Stop polling doorSensor/query forever once a lock is confirmed sensor-less

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -15,6 +15,7 @@ from .capture import LockTrafficCapture
 from .const import DOMAIN, TT_API, TT_CAPTURE, TT_GATEWAYS, TT_LOCKS
 from .coordinator import GatewaysUpdateCoordinator, LockUpdateCoordinator
 from .services import Services
+from .store import LockStateStore
 from .webhook import WebhookHandler
 
 PLATFORMS: list[Platform] = [
@@ -30,6 +31,11 @@ DETAIL_FILL_CONCURRENCY = 3
 # generator) - marks the one LockTrafficCapture shared by every loaded
 # config entry, so a second TTLock account doesn't get a second buffer.
 _CAPTURE_KEY = "_capture"
+
+# Same pattern as _CAPTURE_KEY: one LockStateStore shared by every loaded
+# config entry, since it's a single JSON file keyed by lock ID, not
+# per-account state.
+_STORE_KEY = "_lock_state_store"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,6 +79,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         capture = LockTrafficCapture()
         domain_data[_CAPTURE_KEY] = capture
 
+    store = domain_data.get(_STORE_KEY)
+    if store is None:
+        store = LockStateStore(hass)
+        domain_data[_STORE_KEY] = store
+
     client = TTLockApi(aiohttp_client.async_get_clientsession(hass), session, capture)
 
     domain_data[entry.entry_id] = {
@@ -81,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     locks = [
-        LockUpdateCoordinator(hass, entry, client, summary, capture)
+        LockUpdateCoordinator(hass, entry, client, summary, capture, store)
         for summary in await client.get_locks()
     ]
     hass.data[DOMAIN][entry.entry_id][TT_LOCKS] = locks
@@ -135,5 +146,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # is still loaded" here.
         if not any(not key.startswith("_") for key in domain_data):
             domain_data.pop(_CAPTURE_KEY, None)
+            domain_data.pop(_STORE_KEY, None)
 
     return unload_ok

--- a/custom_components/ttlock/binary_sensor.py
+++ b/custom_components/ttlock/binary_sensor.py
@@ -17,9 +17,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import (
     GatewaysUpdateCoordinator,
+    async_add_when_sensor_present,
     gateway_coordinator,
     lock_coordinators,
-    sensor_present,
 )
 from .entity import BaseLockEntity
 
@@ -33,19 +33,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up all the locks for the config entry."""
 
-    async_add_entities(
-        [
-            entity
-            for coordinator in lock_coordinators(hass, entry)
-            for entity in (
-                PassageMode(coordinator),
-                Sensor(coordinator)
-                if sensor_present(coordinator.data.sensor)
-                else None,
-            )
-            if entity is not None
-        ]
-    )
+    coordinators = list(lock_coordinators(hass, entry))
+
+    async_add_entities([PassageMode(coordinator) for coordinator in coordinators])
+
+    for lock_coordinator in coordinators:
+        async_add_when_sensor_present(
+            lock_coordinator,
+            lambda lock_coordinator=lock_coordinator: async_add_entities(
+                [Sensor(lock_coordinator)]
+            ),
+        )
 
     coordinator = gateway_coordinator(hass, entry)
     async_add_entities(

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -12,6 +12,7 @@ the webhook path in favor of "just poll faster."
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -35,10 +36,12 @@ from .models import (
     Gateway,
     LockSummary,
     PassageModeConfig,
+    Sensor,
     SensorState,
     State,
     WebhookEvent,
 )
+from .store import LockStateStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,6 +49,12 @@ NOT_CONNECTABLE_REASON = (
     "No gateway paired and no WiFi — TTLock's cloud can't reach this lock. "
     "Live data isn't available until connectivity is restored."
 )
+
+# TTLock's doorSensor/query can't distinguish "no sensor paired" from a
+# transient failure (see api.get_sensor), so a lock only counts as confirmed
+# absent after this many consecutive failed checks - see
+# LockUpdateCoordinator._check_for_sensor.
+SENSOR_ABSENT_AFTER_FAILURES = 3
 
 
 @dataclass
@@ -119,6 +128,35 @@ def sensor_present(instance: SensorData | None) -> TypeGuard[SensorData]:
     return instance is not None and instance.present
 
 
+def async_add_when_sensor_present(
+    coordinator: LockUpdateCoordinator, add_entities: Callable[[], None]
+) -> None:
+    """Call `add_entities` once presence is confirmed - now, or later.
+
+    Door-sensor presence isn't known at the cheap lock/list stage entities
+    are created from at platform setup - it's only filled in once the
+    coordinator's first refresh completes, which __init__.py runs in the
+    background *after* platforms are set up (see _fill_lock_details), so
+    sensor-backed entities can't just check coordinator.data.sensor at setup
+    time. Instead: add immediately if presence is already known, otherwise
+    watch for the update that confirms it and add then.
+    """
+    if sensor_present(coordinator.data.sensor):
+        add_entities()
+        return
+
+    remove: Callable[[], None] | None = None
+
+    @callback
+    def _check_and_add() -> None:
+        if sensor_present(coordinator.data.sensor):
+            add_entities()
+            if remove is not None:
+                remove()
+
+    remove = coordinator.async_add_listener(_check_and_add)
+
+
 @contextmanager
 def lock_action(controller: LockUpdateCoordinator):
     """Wrap a lock action so that in-progress state is managed correctly."""
@@ -169,6 +207,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         api: TTLockApi,
         summary: LockSummary,
         capture: LockTrafficCapture,
+        store: LockStateStore,
     ) -> None:
         """Initialize the update co-ordinator for a single lock."""
         self.api = api
@@ -177,6 +216,12 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         self.has_gateway = summary.hasGateway
         self.feature_value = summary.featureValue
         self._capture = capture
+        self._store = store
+
+        # Whether we've already made this restart's one-shot door-sensor
+        # recheck (see _check_for_sensor) - deliberately in-memory, not
+        # persisted, so it naturally resets to False on every restart.
+        self._sensor_recheck_done = False
 
         super().__init__(
             hass,
@@ -217,15 +262,10 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
                 if new_data.sensor is None:
                     new_data.sensor = SensorData()
 
-                # only fetch sensor metadata once a day
-                if (
-                    new_data.sensor.last_fetched is None
-                    or new_data.sensor.last_fetched < dt_util.now() - timedelta(days=1)
-                ):
-                    sensor = await self.api.get_sensor(self.lock_id)
-                    new_data.sensor.last_fetched = dt_util.now()
-                    if sensor:
-                        new_data.sensor.battery = sensor.battery_level
+                if sensor_present(new_data.sensor):
+                    await self._update_present_sensor(new_data.sensor)
+                else:
+                    await self._check_for_sensor(new_data.sensor)
             else:
                 new_data.sensor = None
 
@@ -256,6 +296,87 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             raise UpdateFailed(err) from err
         else:
             return new_data
+
+    async def _refresh_sensor(self, sensor: SensorData) -> Sensor | None:
+        """Query the door sensor endpoint and stamp when we last did so."""
+        result = await self.api.get_sensor(self.lock_id)
+        sensor.last_fetched = dt_util.now()
+        return result
+
+    async def _update_present_sensor(self, sensor: SensorData) -> None:
+        """A sensor is already known-present; refresh its battery once a day."""
+        if (
+            sensor.last_fetched is not None
+            and sensor.last_fetched >= dt_util.now() - timedelta(days=1)
+        ):
+            return
+
+        result = await self._refresh_sensor(sensor)
+        if result:
+            sensor.battery = result.battery_level
+
+    async def _check_for_sensor(self, sensor: SensorData) -> None:
+        """No sensor confirmed present yet - probe for one.
+
+        TTLock's API can't distinguish "no sensor paired" from a transient
+        failure (see api.get_sensor), so we only give up after
+        SENSOR_ABSENT_AFTER_FAILURES consecutive failures, persisted via
+        self._store so the count - and the final verdict - survive HA
+        restarts. Once given up, re-probe just once per restart
+        (self._sensor_recheck_done) rather than resuming the failure count
+        from scratch, which would poll forever on a setup that restarts HA
+        often.
+        """
+        stored = await self._store.async_get(self.lock_id)
+        confirmed_absent = stored.get("door_sensor_confirmed_absent", False)
+
+        if confirmed_absent:
+            if self._sensor_recheck_done:
+                return
+            self._sensor_recheck_done = True
+        else:
+            last_failed = stored.get("door_sensor_last_failed_req")
+            last_failed_dt = (
+                dt_util.parse_datetime(last_failed) if last_failed else None
+            )
+            if (
+                last_failed_dt is not None
+                and last_failed_dt >= dt_util.now() - timedelta(days=1)
+            ):
+                return
+
+        result = await self._refresh_sensor(sensor)
+
+        if result:
+            sensor.battery = result.battery_level
+            await self._store.async_update(
+                self.lock_id,
+                door_sensor_confirmed_absent=False,
+                door_sensor_count_failed_req=0,
+            )
+            return
+
+        if confirmed_absent:
+            # this was just this restart's one-shot recheck, and it also
+            # failed - leave the persisted verdict as-is rather than
+            # growing the failure count forever across restarts
+            return
+
+        failures = stored.get("door_sensor_count_failed_req", 0) + 1
+        newly_confirmed_absent = failures >= SENSOR_ABSENT_AFTER_FAILURES
+        if newly_confirmed_absent:
+            # this call is what crossed the threshold, so it also counts as
+            # this instance's one-shot recheck - otherwise the very next
+            # scheduled refresh (15 minutes later, not gated by the daily
+            # throttle above) would see confirmed_absent for "the first
+            # time" and fire one more unbudgeted check before going quiet.
+            self._sensor_recheck_done = True
+        await self._store.async_update(
+            self.lock_id,
+            door_sensor_last_failed_req=dt_util.now().isoformat(),
+            door_sensor_count_failed_req=failures,
+            door_sensor_confirmed_absent=newly_confirmed_absent,
+        )
 
     @callback
     def _async_refresh_finished(self) -> None:
@@ -353,10 +474,16 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
 
     @property
     def entities(self) -> list[Entity]:
-        """Entities belonging to this co-ordinator."""
+        """Entities belonging to this co-ordinator.
+
+        Not every registered listener is a bound entity method -
+        async_add_when_sensor_present registers a plain closure while it
+        waits to confirm door-sensor presence, which has no `__self__` at
+        all, so that has to be tolerated rather than assumed away.
+        """
         result: list[Entity] = []
         for listener_callback, _ in list(self._listeners.values()):
-            owner = listener_callback.__self__  # ty: ignore[unresolved-attribute] - checking for bound-method listeners
+            owner = getattr(listener_callback, "__self__", None)
             if isinstance(owner, Entity):
                 result.append(owner)
         return result

--- a/custom_components/ttlock/sensor.py
+++ b/custom_components/ttlock/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .coordinator import lock_coordinators, sensor_present
+from .coordinator import async_add_when_sensor_present, lock_coordinators
 from .entity import BaseLockEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,21 +24,27 @@ async def async_setup_entry(
 ) -> None:
     """Set up all the locks for the config entry."""
 
+    coordinators = list(lock_coordinators(hass, entry))
+
     async_add_entities(
         [
             entity
-            for coordinator in lock_coordinators(hass, entry)
+            for coordinator in coordinators
             for entity in (
                 LockBattery(coordinator),
                 LockOperator(coordinator),
                 LockTrigger(coordinator),
-                SensorBattery(coordinator)
-                if sensor_present(coordinator.data.sensor)
-                else None,
             )
-            if entity is not None
         ]
     )
+
+    for lock_coordinator in coordinators:
+        async_add_when_sensor_present(
+            lock_coordinator,
+            lambda lock_coordinator=lock_coordinator: async_add_entities(
+                [SensorBattery(lock_coordinator)]
+            ),
+        )
 
 
 class LockBattery(BaseLockEntity, SensorEntity):

--- a/custom_components/ttlock/store.py
+++ b/custom_components/ttlock/store.py
@@ -1,0 +1,54 @@
+"""Persisted per-lock state that must survive Home Assistant restarts.
+
+Coordinator state (coordinator.py) is otherwise entirely in-memory and
+recreated fresh on every restart. This exists for the rare bit of state that
+needs to survive that - e.g. whether a lock's door sensor has been confirmed
+absent, since TTLock's API can't distinguish "no sensor paired" from a
+transient failure (see LockUpdateCoordinator's door-sensor handling), so
+re-guessing from scratch on every restart would defeat the point of giving
+up.
+
+Backed by a single `homeassistant.helpers.storage.Store`, keyed by lock ID,
+shared across every loaded config entry the same way LockTrafficCapture is
+(see __init__.py's _STORE_KEY) - one JSON file for the whole install, not one
+per account.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}_lock_state"
+
+
+class LockStateStore:
+    """Small persisted key/value store, one dict of attributes per lock ID."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize, wrapping a Store that's only actually read on first use."""
+        self._store: Store[dict[str, dict[str, Any]]] = Store(
+            hass, STORAGE_VERSION, STORAGE_KEY
+        )
+        self._data: dict[str, dict[str, Any]] | None = None
+
+    async def _async_data(self) -> dict[str, dict[str, Any]]:
+        if self._data is None:
+            self._data = await self._store.async_load() or {}
+        return self._data
+
+    async def async_get(self, lock_id: int) -> dict[str, Any]:
+        """Return the persisted attributes for a lock, or {} if none yet."""
+        data = await self._async_data()
+        return data.get(str(lock_id), {})
+
+    async def async_update(self, lock_id: int, **attributes: Any) -> None:
+        """Merge `attributes` into a lock's persisted entry and save."""
+        data = await self._async_data()
+        data[str(lock_id)] = {**data.get(str(lock_id), {}), **attributes}
+        await self._store.async_save(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from custom_components.ttlock.models import (
     PassageModeConfig,
     Sensor,
 )
+from custom_components.ttlock.store import LockStateStore
 from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
@@ -156,7 +157,9 @@ async def coordinator(hass, api):
     summary = LockSummary(
         lockId=7252408, lockAlias="Test Lock", lockMac="00:00:00:00:00:00", hasGateway=1
     )
-    return LockUpdateCoordinator(hass, config_entry, api, summary, LockTrafficCapture())
+    return LockUpdateCoordinator(
+        hass, config_entry, api, summary, LockTrafficCapture(), LockStateStore(hass)
+    )
 
 
 class MockApiData(NamedTuple):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,39 @@
+"""Test the binary_sensor platform's entity setup.
+
+See coordinator.py's async_add_when_sensor_present: door-sensor presence
+isn't known at platform-setup time - it's filled in by each lock's first
+refresh, which __init__.py runs in the background after platforms are set up
+(_fill_lock_details) - so the Sensor entity has to be added once that
+refresh confirms presence, not decided up front.
+"""
+
+
+async def test_sensor_entity_appears_once_presence_confirmed(
+    hass, component_setup, mock_api_responses
+):
+    mock_api_responses("with_sensor")
+    await component_setup()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("binary_sensor.front_door_sensor")
+    assert state is not None
+
+
+async def test_sensor_entity_not_created_when_absent(
+    hass, component_setup, mock_api_responses
+):
+    mock_api_responses("sensor_not_installed")
+    await component_setup()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("binary_sensor.front_door_sensor") is None
+
+
+async def test_passage_mode_entity_created_immediately(
+    hass, component_setup, mock_api_responses
+):
+    """Unlike Sensor, PassageMode doesn't depend on the deferred refresh."""
+    mock_api_responses("default")
+    await component_setup()
+
+    assert hass.states.get("binary_sensor.front_door_passage_mode") is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -15,6 +15,8 @@ from custom_components.ttlock.coordinator import (
     GatewaysUpdateCoordinator,
     LockState,
     LockUpdateCoordinator,
+    SensorData,
+    async_add_when_sensor_present,
 )
 from custom_components.ttlock.models import (
     LockState as WireLockState,
@@ -136,6 +138,50 @@ class TestLockState:
             assert lock_state.auto_lock_delay(ts(time)) is None
 
 
+class TestAsyncAddWhenSensorPresent:
+    """coordinator.py's __init__.py always calls this before a lock's first
+    refresh has run (see async_add_when_sensor_present's own docstring), so
+    the "already present" branch is never exercised through the real
+    component_setup flow - test it directly as a unit instead.
+    """
+
+    async def test_adds_immediately_when_already_present(
+        self, coordinator: LockUpdateCoordinator
+    ):
+        coordinator.data.sensor = SensorData(battery=50)
+        calls = []
+
+        async_add_when_sensor_present(coordinator, lambda: calls.append(True))
+
+        assert calls == [True]
+
+    async def test_defers_until_presence_confirmed(
+        self, coordinator: LockUpdateCoordinator
+    ):
+        calls = []
+
+        async_add_when_sensor_present(coordinator, lambda: calls.append(True))
+        assert calls == []
+
+        coordinator.data.sensor = SensorData(battery=50)
+        coordinator.async_update_listeners()
+
+        assert calls == [True]
+
+    async def test_listener_is_removed_after_firing(
+        self, coordinator: LockUpdateCoordinator
+    ):
+        calls = []
+
+        async_add_when_sensor_present(coordinator, lambda: calls.append(True))
+
+        coordinator.data.sensor = SensorData(battery=50)
+        coordinator.async_update_listeners()
+        coordinator.async_update_listeners()
+
+        assert calls == [True]
+
+
 class TestLockUpdateCoordinator:
     class TestAsyncRefresh:
         async def test_coordinator_loads_data(
@@ -193,6 +239,22 @@ class TestLockUpdateCoordinator:
             t1 = coordinator.data.sensor.last_fetched
 
             assert t0 == t1
+
+        async def test_present_sensor_battery_refetched_after_a_day(
+            self, coordinator: LockUpdateCoordinator, mock_api_responses
+        ):
+            mock_api_responses("with_sensor")
+
+            await coordinator.async_refresh()
+            assert coordinator.data.sensor is not None
+            coordinator.data.sensor.last_fetched = dt_util.now() - timedelta(days=2)
+
+            await coordinator.async_refresh()
+
+            assert coordinator.data.sensor is not None
+            assert coordinator.data.sensor.last_fetched > dt_util.now() - timedelta(
+                seconds=3
+            )
 
         async def test_locked_state_reverified_every_refresh(
             self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -22,6 +22,7 @@ from custom_components.ttlock.models import (
     PassageModeConfig,
     WebhookEvent,
 )
+from custom_components.ttlock.store import LockStateStore
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -268,7 +269,12 @@ class TestLockUpdateCoordinator:
                 hasGateway=0,
             )
             coordinator = LockUpdateCoordinator(
-                hass, config_entry, api, summary, LockTrafficCapture()
+                hass,
+                config_entry,
+                api,
+                summary,
+                LockTrafficCapture(),
+                LockStateStore(hass),
             )
 
             assert coordinator.connectable is False
@@ -277,6 +283,205 @@ class TestLockUpdateCoordinator:
             await coordinator.async_refresh()
 
             assert coordinator.last_update_success is False
+
+    class TestSensorAbsenceTracking:
+        """See coordinator.py's _check_for_sensor - the whole reason issue
+        #181 exists: TTLock's doorSensor/query can't distinguish "no sensor"
+        from a transient failure, so we only give up after repeated
+        failures, persist that verdict, and only re-probe once per restart
+        afterwards.
+        """
+
+        LOCK_ID = 7252408
+
+        def _make_coordinator(
+            self, hass, api, store: LockStateStore
+        ) -> LockUpdateCoordinator:
+            config_entry = MockConfigEntry(domain=DOMAIN)
+            config_entry.add_to_hass(hass)
+            summary = LockSummary(
+                lockId=self.LOCK_ID,
+                lockAlias="Test Lock",
+                lockMac="00:00:00:00:00:00",
+                hasGateway=1,
+            )
+            return LockUpdateCoordinator(
+                hass, config_entry, api, summary, LockTrafficCapture(), store
+            )
+
+        async def _expire_daily_gate(self, store: LockStateStore) -> None:
+            await store.async_update(
+                self.LOCK_ID,
+                door_sensor_last_failed_req=(
+                    dt_util.now() - timedelta(days=2)
+                ).isoformat(),
+            )
+
+        async def test_does_not_recheck_within_the_same_day(
+            self, hass, api, mock_api_responses
+        ):
+            mock_api_responses("sensor_not_installed")
+            store = LockStateStore(hass)
+            coordinator = self._make_coordinator(hass, api, store)
+
+            await coordinator.async_refresh()
+            await coordinator.async_refresh()
+
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_count_failed_req"] == 1
+
+        async def test_confirms_absent_after_three_consecutive_failures(
+            self, hass, api, mock_api_responses
+        ):
+            mock_api_responses("sensor_not_installed")
+            store = LockStateStore(hass)
+            coordinator = self._make_coordinator(hass, api, store)
+
+            await coordinator.async_refresh()
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_count_failed_req"] == 1
+            assert entry.get("door_sensor_confirmed_absent", False) is False
+
+            await self._expire_daily_gate(store)
+            await coordinator.async_refresh()
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_count_failed_req"] == 2
+            assert entry.get("door_sensor_confirmed_absent", False) is False
+
+            await self._expire_daily_gate(store)
+            await coordinator.async_refresh()
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_count_failed_req"] == 3
+            assert entry["door_sensor_confirmed_absent"] is True
+
+        async def test_no_extra_check_immediately_after_crossing_the_threshold(
+            self, hass, api, mock_api_responses, monkeypatch
+        ):
+            """The refresh that crosses the failure threshold must itself
+            count as this instance's one-shot recheck - otherwise the very
+            next scheduled refresh (minutes later, not gated by the daily
+            throttle that applied while still counting) would see
+            confirmed_absent for "the first time" and fire one more
+            unbudgeted call before finally going quiet.
+            """
+            mock_api_responses("sensor_not_installed")
+            store = LockStateStore(hass)
+            coordinator = self._make_coordinator(hass, api, store)
+
+            await coordinator.async_refresh()
+            await self._expire_daily_gate(store)
+            await coordinator.async_refresh()
+            await self._expire_daily_gate(store)
+            await coordinator.async_refresh()
+
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_confirmed_absent"] is True
+
+            call_count = 0
+
+            async def counting_get_sensor(self, lock_id):
+                nonlocal call_count
+                call_count += 1
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_sensor",
+                counting_get_sensor,
+            )
+
+            await coordinator.async_refresh()
+
+            assert call_count == 0
+
+        async def test_success_resets_failure_count(
+            self, hass, api, mock_api_responses
+        ):
+            store = LockStateStore(hass)
+            await store.async_update(self.LOCK_ID, door_sensor_count_failed_req=2)
+
+            mock_api_responses("with_sensor")
+            coordinator = self._make_coordinator(hass, api, store)
+            await coordinator.async_refresh()
+
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_count_failed_req"] == 0
+            assert entry["door_sensor_confirmed_absent"] is False
+
+        async def test_new_instance_gets_one_recheck_after_confirmed_absent(
+            self, hass, api, mock_api_responses, monkeypatch
+        ):
+            """Simulates an HA restart: a fresh LockUpdateCoordinator sharing
+            the persisted store makes exactly one check, not the full
+            three-strike sequence again.
+            """
+            mock_api_responses("sensor_not_installed")
+            store = LockStateStore(hass)
+
+            coordinator_a = self._make_coordinator(hass, api, store)
+            await coordinator_a.async_refresh()
+            await self._expire_daily_gate(store)
+            await coordinator_a.async_refresh()
+            await self._expire_daily_gate(store)
+            await coordinator_a.async_refresh()
+
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_confirmed_absent"] is True
+
+            call_count = 0
+
+            async def counting_get_sensor(self, lock_id):
+                nonlocal call_count
+                call_count += 1
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_sensor",
+                counting_get_sensor,
+            )
+
+            coordinator_b = self._make_coordinator(hass, api, store)
+            await coordinator_b.async_refresh()
+            await coordinator_b.async_refresh()
+            await coordinator_b.async_refresh()
+
+            assert call_count == 1
+
+        async def test_confirmed_absent_recheck_success_clears_state(
+            self, hass, api, mock_api_responses
+        ):
+            mock_api_responses("with_sensor")
+            store = LockStateStore(hass)
+            await store.async_update(
+                self.LOCK_ID,
+                door_sensor_confirmed_absent=True,
+                door_sensor_count_failed_req=3,
+            )
+
+            coordinator = self._make_coordinator(hass, api, store)
+            await coordinator.async_refresh()
+
+            assert coordinator.data.sensor is not None
+            assert coordinator.data.sensor.present is True
+
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_confirmed_absent"] is False
+            assert entry["door_sensor_count_failed_req"] == 0
+
+        async def test_confirmed_absent_recheck_failure_leaves_state_unchanged(
+            self, hass, api, mock_api_responses
+        ):
+            mock_api_responses("sensor_not_installed")
+            store = LockStateStore(hass)
+            await store.async_update(
+                self.LOCK_ID,
+                door_sensor_confirmed_absent=True,
+                door_sensor_count_failed_req=3,
+            )
+
+            coordinator = self._make_coordinator(hass, api, store)
+            await coordinator.async_refresh()
+
+            entry = await store.async_get(self.LOCK_ID)
+            assert entry["door_sensor_confirmed_absent"] is True
+            assert entry["door_sensor_count_failed_req"] == 3
 
     class TestProcessWebhookData:
         async def test_lock_works(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -16,6 +16,7 @@ from custom_components.ttlock.diagnostics import (
     async_get_device_diagnostics,
 )
 from custom_components.ttlock.models import Gateway, LockSummary
+from custom_components.ttlock.store import LockStateStore
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -203,7 +204,9 @@ async def _refresh_captured_lock(hass: HomeAssistant) -> tuple[dict, dict]:
             lockMac="16:72:4C:CC:01:C4",
             hasGateway=1,
         )
-        coordinator = LockUpdateCoordinator(hass, config_entry, api, summary, capture)
+        coordinator = LockUpdateCoordinator(
+            hass, config_entry, api, summary, capture, LockStateStore(hass)
+        )
         await coordinator.async_refresh()
 
         hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,40 @@
+"""Test the sensor platform's entity setup.
+
+See coordinator.py's async_add_when_sensor_present: door-sensor presence
+isn't known at platform-setup time - it's filled in by each lock's first
+refresh, which __init__.py runs in the background after platforms are set up
+(_fill_lock_details) - so SensorBattery has to be added once that refresh
+confirms presence, not decided up front.
+"""
+
+
+async def test_sensor_battery_entity_appears_once_presence_confirmed(
+    hass, component_setup, mock_api_responses
+):
+    mock_api_responses("with_sensor")
+    await component_setup()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.front_door_sensor_battery")
+    assert state is not None
+    assert state.state == "85"
+
+
+async def test_sensor_battery_entity_not_created_when_absent(
+    hass, component_setup, mock_api_responses
+):
+    mock_api_responses("sensor_not_installed")
+    await component_setup()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("sensor.front_door_sensor_battery") is None
+
+
+async def test_lock_battery_entity_created_immediately(
+    hass, component_setup, mock_api_responses
+):
+    """Unlike SensorBattery, LockBattery doesn't depend on the deferred refresh."""
+    mock_api_responses("default")
+    await component_setup()
+
+    assert hass.states.get("sensor.front_door_battery") is not None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,38 @@
+"""Test the persisted per-lock LockStateStore."""
+
+from custom_components.ttlock.store import LockStateStore
+
+
+async def test_get_returns_empty_dict_for_unknown_lock(hass):
+    store = LockStateStore(hass)
+    assert await store.async_get(123) == {}
+
+
+async def test_update_then_get_round_trips(hass):
+    store = LockStateStore(hass)
+    await store.async_update(123, foo="bar", count=1)
+    assert await store.async_get(123) == {"foo": "bar", "count": 1}
+
+
+async def test_update_merges_rather_than_replaces(hass):
+    store = LockStateStore(hass)
+    await store.async_update(123, foo="bar")
+    await store.async_update(123, count=1)
+    assert await store.async_get(123) == {"foo": "bar", "count": 1}
+
+
+async def test_locks_are_independent(hass):
+    store = LockStateStore(hass)
+    await store.async_update(123, foo="bar")
+    await store.async_update(456, foo="baz")
+    assert await store.async_get(123) == {"foo": "bar"}
+    assert await store.async_get(456) == {"foo": "baz"}
+
+
+async def test_state_persists_across_store_instances(hass):
+    """A second LockStateStore(hass) - as happens on HA restart - must see
+    what a previous instance saved, since the whole point is surviving
+    restarts.
+    """
+    await LockStateStore(hass).async_update(123, foo="bar")
+    assert await LockStateStore(hass).async_get(123) == {"foo": "bar"}


### PR DESCRIPTION
## Summary

- TTLock's `featureValue` bit only means a lock model *supports* a door sensor, not that one is paired, and `doorSensor/query` returns the same generic error for "no sensor" as for a transient failure - so the existing once-a-day poll ran forever for locks that will never have a sensor.
- Now gives up after 3 consecutive failures and persists that verdict (plus the in-progress failure count) via a new small per-lock `LockStateStore`, so it survives HA restarts instead of resetting the count to zero every time. Once confirmed absent, re-probes exactly once per restart rather than resuming the daily cycle.
- Also fixes a regression surfaced along the way: the door-sensor-backed entities (`binary_sensor`'s `Sensor`, `sensor`'s `SensorBattery`) were never being created at all, for any lock, because platform setup decided entity creation from `coordinator.data.sensor` before each lock's first refresh (moved to a background task by an earlier progressive-loading change) had ever run. They're now added dynamically once a coordinator confirms presence.

Closes #181

## Test plan

- [x] `script/check` (lint, type-check, full test suite) passes
- [x] New tests cover: 3-strike failure counting, confirmed-absent stops polling, one recheck per restart (including a regression test for a bug the threshold-crossing call itself introduced an extra unbudgeted check), recheck success/failure paths, and that the `Sensor`/`SensorBattery` entities now actually appear once presence is confirmed
- [x] Ran through `/code-review` (Standards + Spec axes) before commit; one real bug found and fixed prior to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHBxYBgv3cx6ySe5pVpkEK