### PR TITLE
Exclude test code from coverage measurement

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -54,11 +54,11 @@ jobs:
             --timeout=9 \
             --durations=10 \
             -n auto \
-            --cov custom_components.ttlock \
+            --cov \
             --cov-report=xml \
             -o console_output_style=count \
             -p no:sugar \
-            --cov --junitxml=junit.xml -o junit_family=legacy \
+            --junitxml=junit.xml -o junit_family=legacy \
             tests
       - name: Upload coverage reports to Codecov
         if: ${{ !cancelled() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ dependencies = [
 [tool.ty.environment]
 python-version = "3.13"
 
+[tool.coverage.run]
+source = ["custom_components.ttlock"]
+omit = ["tests/*"]
+
 [tool.pytest.ini_options]
 log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
## Summary
- The CI test job passed pytest-cov both `--cov custom_components.ttlock` and a bare `--cov` later in the same command. The bare `--cov` re-enables coverage measurement over the whole working directory, which pulls `tests/` into the coverage report alongside the integration source.
- Added a `[tool.coverage.run]` section to `pyproject.toml` (`source = ["custom_components.ttlock"]`, `omit = ["tests/*"]`) so the scoping lives in config rather than only in a CLI flag, and dropped the duplicate `--cov` flag from `.github/workflows/lint_test.yml`.

## Test plan
- [x] `script/check` (lint, type-check, full test suite — 236 passed)
- [x] Ran `uv run pytest --cov --cov-report=term tests/test_store.py` locally and confirmed the coverage table only lists `custom_components/ttlock/*` files, with no `tests/*` rows.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZRjyJ31maQAbLbWntQFSb)_