### PR TITLE
Show which gateway a lock is connected to

### DIFF
--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -45,6 +45,7 @@ from .models import (
     Card,
     Fingerprint,
     Gateway,
+    GatewayLink,
     Lock,
     LockRecord,
     LockState,
@@ -235,6 +236,15 @@ class TTLockApi:
         """Enumerate all gateways in the account."""
         res = await self.get("gateway/list", pageNo=1, pageSize=1000)
         return [Gateway.model_validate(gateway) for gateway in res["list"]]
+
+    async def get_gateways_for_lock(self, lock_id: int) -> list[GatewayLink]:
+        """List gateways currently in range of a lock, best signal first."""
+        res = await self.get("gateway/listByLock", lockId=lock_id)
+        return sorted(
+            (GatewayLink.model_validate(gateway) for gateway in res["list"]),
+            key=lambda gateway: gateway.rssi,
+            reverse=True,
+        )
 
     async def get_lock(self, lock_id: int) -> Lock:
         """Get a lock by ID."""

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -34,6 +34,7 @@ from .const import DOMAIN, SIGNAL_NEW_DATA, TT_GATEWAYS, TT_LOCKS
 from .models import (
     Features,
     Gateway,
+    GatewayLink,
     LockSummary,
     PassageModeConfig,
     Sensor,
@@ -90,6 +91,12 @@ class LockState:
     sensor: SensorData | None = None
     auto_lock_seconds: int | None = None
     passage_mode_config: PassageModeConfig | None = None
+    gateways: list[GatewayLink] = field(default_factory=list)
+
+    @property
+    def best_gateway(self) -> GatewayLink | None:
+        """The gateway currently used to reach the lock, by best RSSI."""
+        return self.gateways[0] if self.gateways else None
 
     def passage_mode_active(self, current_date: datetime | None = None) -> bool:
         """Check if passage mode is currently active."""
@@ -292,6 +299,11 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             new_data.passage_mode_config = await self.api.get_lock_passage_mode_config(
                 self.lock_id
             )
+
+            if self.has_gateway:
+                new_data.gateways = await self.api.get_gateways_for_lock(self.lock_id)
+            else:
+                new_data.gateways = []
         except Exception as err:
             raise UpdateFailed(err) from err
         else:
@@ -462,8 +474,16 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Device info for the lock."""
-        return DeviceInfo(
+        """Device info for the lock.
+
+        via_device links to the best-RSSI gateway currently in range (see
+        GatewayLink), matching the identifier GatewaySensor registers in
+        binary_sensor.py - this is what makes the lock's device page show
+        "via device: <gateway>". Re-pushed on every successful poll by
+        _async_refresh_finished, so it tracks the gateway TTLock's cloud
+        would actually use if the best one changes.
+        """
+        info = DeviceInfo(
             identifiers={(DOMAIN, self.data.mac)},
             manufacturer="TT Lock",
             model=self.data.model,
@@ -471,6 +491,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             sw_version=self.data.firmware_version,
             hw_version=self.data.hardware_version,
         )
+        if best_gateway := self.data.best_gateway:
+            info["via_device"] = (DOMAIN, best_gateway.mac)
+        return info
 
     @property
     def entities(self) -> list[Entity]:

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -116,22 +116,24 @@ class Sensor(BaseModel):
     mac: str = Field(..., alias="mac")
 
 
-class Gateway(BaseModel):
-    """Gateway details."""
+class GatewayIdentity(BaseModel):
+    """Fields common to every gateway/* response shape."""
 
     id: int = Field(..., alias="gatewayId")
     name: str = Field(..., alias="gatewayName")
     mac: str = Field(..., alias="gatewayMac")
+
+
+class Gateway(GatewayIdentity):
+    """Gateway details."""
+
     is_online: bool = Field(..., alias="isOnline")
     network_name: str | None = Field(None, alias="networkName")
 
 
-class GatewayLink(BaseModel):
+class GatewayLink(GatewayIdentity):
     """A gateway currently in range of a lock, from gateway/listByLock."""
 
-    id: int = Field(..., alias="gatewayId")
-    name: str = Field(..., alias="gatewayName")
-    mac: str = Field(..., alias="gatewayMac")
     rssi: int
 
 

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -126,6 +126,15 @@ class Gateway(BaseModel):
     network_name: str | None = Field(None, alias="networkName")
 
 
+class GatewayLink(BaseModel):
+    """A gateway currently in range of a lock, from gateway/listByLock."""
+
+    id: int = Field(..., alias="gatewayId")
+    name: str = Field(..., alias="gatewayName")
+    mac: str = Field(..., alias="gatewayMac")
+    rssi: int
+
+
 class LockState(BaseModel):
     """Lock state."""
 

--- a/custom_components/ttlock/sensor.py
+++ b/custom_components/ttlock/sensor.py
@@ -3,10 +3,20 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, STATE_UNAVAILABLE
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    STATE_UNAVAILABLE,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -34,6 +44,7 @@ async def async_setup_entry(
                 LockBattery(coordinator),
                 LockOperator(coordinator),
                 LockTrigger(coordinator),
+                *([LockGateway(coordinator)] if coordinator.has_gateway else []),
             )
         ]
     )
@@ -117,3 +128,40 @@ class SensorBattery(BaseLockEntity, SensorEntity):
             if self.coordinator.data.sensor
             else None
         )
+
+
+class LockGateway(BaseLockEntity, SensorEntity):
+    """RSSI of the gateway currently used to reach the lock.
+
+    Diagnostic and disabled by default - the same connectivity is already
+    surfaced via device_info.via_device (coordinator.py); this is for
+    troubleshooting placement/coverage, not everyday use.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def _update_from_coordinator(self) -> None:
+        """Fetch state from the device."""
+        self._attr_name = f"{self.coordinator.data.name} Gateway Signal"
+        best = self.coordinator.data.best_gateway
+        self._attr_native_value = best.rssi if best else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Name/mac of the connected gateway, plus any others in range."""
+        gateways = self.coordinator.data.gateways
+        if not gateways:
+            return None
+        best, *others = gateways
+        return {
+            "gateway": best.name,
+            "mac": best.mac,
+            "other_gateways": [
+                {"name": gateway.name, "mac": gateway.mac, "rssi": gateway.rssi}
+                for gateway in others
+            ],
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,6 +248,9 @@ def mock_api_responses(monkeypatch, mock_data_factory):
         async def mock_get_gateways(*args, **kwargs):
             return []
 
+        async def mock_get_gateways_for_lock(*args, **kwargs):
+            return []
+
         monkeypatch.setattr(
             "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
         )
@@ -271,6 +274,10 @@ def mock_api_responses(monkeypatch, mock_data_factory):
         monkeypatch.setattr(
             "custom_components.ttlock.api.TTLockApi.get_gateways",
             mock_get_gateways,
+        )
+        monkeypatch.setattr(
+            "custom_components.ttlock.api.TTLockApi.get_gateways_for_lock",
+            mock_get_gateways_for_lock,
         )
 
     return create_mock_responses

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -568,6 +568,34 @@ class TestGetLockAndGateways:
         assert len(gateways) == 1
         assert gateways[0].id == 1
 
+    async def test_get_gateways_for_lock(
+        self, ttlock_api: TTLockApi, mocker: AiohttpClientMocker
+    ):
+        mocker.get(
+            f"{BASE}gateway/listByLock",
+            json={
+                "list": [
+                    {
+                        "gatewayId": 1,
+                        "gatewayName": "Weak",
+                        "gatewayMac": "00:00:00:00:00:01",
+                        "rssi": -85,
+                    },
+                    {
+                        "gatewayId": 2,
+                        "gatewayName": "Strong",
+                        "gatewayMac": "00:00:00:00:00:02",
+                        "rssi": -60,
+                    },
+                ]
+            },
+        )
+
+        gateways = await ttlock_api.get_gateways_for_lock(7252408)
+
+        assert [gateway.name for gateway in gateways] == ["Strong", "Weak"]
+        assert mocker.mock_calls[0][1].query["lockId"] == "7252408"
+
     async def test_get_lock_passage_mode_config(
         self, ttlock_api: TTLockApi, mocker: AiohttpClientMocker
     ):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,6 +19,7 @@ from custom_components.ttlock.coordinator import (
     async_add_when_sensor_present,
 )
 from custom_components.ttlock.models import (
+    GatewayLink,
     LockState as WireLockState,
     LockSummary,
     PassageModeConfig,
@@ -345,6 +346,102 @@ class TestLockUpdateCoordinator:
             await coordinator.async_refresh()
 
             assert coordinator.last_update_success is False
+
+    class TestGatewayLinks:
+        """gateway/listByLock results feed LockState.gateways/best_gateway,
+        and device_info.via_device (see coordinator.py's device_info
+        docstring for why this matters)."""
+
+        async def test_best_gateway_by_rssi_and_via_device(
+            self,
+            coordinator: LockUpdateCoordinator,
+            mock_api_responses,
+            monkeypatch,
+        ):
+            mock_api_responses("default")
+
+            async def mock_get_gateways_for_lock(*args, **kwargs):
+                return [
+                    GatewayLink(
+                        gatewayId=2,
+                        gatewayName="Strong",
+                        gatewayMac="00:00:00:00:00:02",
+                        rssi=-60,
+                    ),
+                    GatewayLink(
+                        gatewayId=1,
+                        gatewayName="Weak",
+                        gatewayMac="00:00:00:00:00:01",
+                        rssi=-85,
+                    ),
+                ]
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_gateways_for_lock",
+                mock_get_gateways_for_lock,
+            )
+
+            await coordinator.async_refresh()
+
+            assert coordinator.data.best_gateway is not None
+            assert coordinator.data.best_gateway.name == "Strong"
+            assert coordinator.device_info["via_device"] == (
+                DOMAIN,
+                "00:00:00:00:00:02",
+            )
+
+        async def test_no_gateways_in_range_omits_via_device(
+            self,
+            coordinator: LockUpdateCoordinator,
+            mock_api_responses,
+        ):
+            mock_api_responses("default")
+
+            await coordinator.async_refresh()
+
+            assert coordinator.data.best_gateway is None
+            assert "via_device" not in coordinator.device_info
+
+        async def test_wifi_only_lock_never_fetches_gateways(
+            self, hass, api, mock_api_responses, monkeypatch
+        ):
+            mock_api_responses("default")
+
+            called = False
+
+            async def mock_get_gateways_for_lock(*args, **kwargs):
+                nonlocal called
+                called = True
+                return []
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_gateways_for_lock",
+                mock_get_gateways_for_lock,
+            )
+
+            config_entry = MockConfigEntry(domain=DOMAIN)
+            config_entry.add_to_hass(hass)
+            summary = LockSummary(
+                lockId=1,
+                lockAlias="WiFi Only",
+                lockMac="00:00:00:00:00:01",
+                hasGateway=0,
+                featureValue=f"{2**56:X}",  # Features.wifi
+            )
+            wifi_coordinator = LockUpdateCoordinator(
+                hass,
+                config_entry,
+                api,
+                summary,
+                LockTrafficCapture(),
+                LockStateStore(hass),
+            )
+
+            await wifi_coordinator.async_refresh()
+
+            assert wifi_coordinator.connectable is True
+            assert called is False
+            assert wifi_coordinator.data.gateways == []
 
     class TestSensorAbsenceTracking:
         """See coordinator.py's _check_for_sensor - the whole reason issue

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,6 +7,10 @@ refresh, which __init__.py runs in the background after platforms are set up
 confirms presence, not decided up front.
 """
 
+from custom_components.ttlock.const import DOMAIN
+from custom_components.ttlock.models import GatewayLink, LockSummary
+from homeassistant.helpers import entity_registry as er
+
 
 async def test_sensor_battery_entity_appears_once_presence_confirmed(
     hass, component_setup, mock_api_responses
@@ -38,3 +42,96 @@ async def test_lock_battery_entity_created_immediately(
     await component_setup()
 
     assert hass.states.get("sensor.front_door_battery") is not None
+
+
+async def test_gateway_signal_entity_disabled_by_default(
+    hass, component_setup, mock_api_responses
+):
+    mock_api_responses("default")
+    coordinator = await component_setup()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{coordinator.unique_id}-lockgateway"
+    )
+    assert entity_id is not None
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get(entity_id) is None
+
+
+async def test_gateway_signal_entity_reports_best_gateway_and_others(
+    hass, component_setup, mock_api_responses, monkeypatch
+):
+    mock_api_responses("default")
+
+    async def mock_get_gateways_for_lock(*args, **kwargs):
+        return [
+            GatewayLink(
+                gatewayId=2,
+                gatewayName="Strong",
+                gatewayMac="00:00:00:00:00:02",
+                rssi=-60,
+            ),
+            GatewayLink(
+                gatewayId=1,
+                gatewayName="Weak",
+                gatewayMac="00:00:00:00:00:01",
+                rssi=-85,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_gateways_for_lock",
+        mock_get_gateways_for_lock,
+    )
+
+    coordinator = await component_setup()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{coordinator.unique_id}-lockgateway"
+    )
+    assert entity_id is not None
+    registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(coordinator.config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "-60"
+    assert state.attributes["gateway"] == "Strong"
+    assert state.attributes["mac"] == "00:00:00:00:00:02"
+    assert state.attributes["other_gateways"] == [
+        {"name": "Weak", "mac": "00:00:00:00:00:01", "rssi": -85}
+    ]
+
+
+async def test_gateway_signal_entity_not_created_for_wifi_only_lock(
+    hass, component_setup, mock_api_responses, monkeypatch
+):
+    mock_api_responses("default")
+
+    async def mock_get_locks(*args, **kwargs):
+        return [
+            LockSummary(
+                lockId=7252408,
+                lockAlias="Front Door",
+                lockMac="00:00:00:00:00:00",
+                hasGateway=0,
+                featureValue=f"{2**56:X}",  # Features.wifi
+            )
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
+    )
+
+    coordinator = await component_setup()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{coordinator.unique_id}-lockgateway"
+    )
+    assert entity_id is None


### PR DESCRIPTION
## Summary
- Add `TTLockApi.get_gateways_for_lock` (`gateway/listByLock`), returning every gateway currently in range of a lock, sorted best-RSSI-first.
- Link the lock's device-registry entry to the best-signal gateway (`device_info.via_device`), refreshed on every successful poll.
- Add a disabled-by-default diagnostic sensor per gateway-connected lock, reporting the best gateway's RSSI, with the gateway name/mac and any other in-range gateways as attributes.
- Only applies to locks that actually use a gateway (`has_gateway`) — WiFi-only locks are unaffected.

## Test plan
- [x] `script/check` passes (lint, type-check, 243 tests)
- [x] New coverage: `test_api.py::test_get_gateways_for_lock`, `test_coordinator.py::TestGatewayLinks` (best-gateway selection, `via_device`, WiFi-only gating), `test_sensor.py` (disabled-by-default, RSSI + attributes, no entity for WiFi-only locks)
- [x] `/code-review` (Standards + Spec) run against `develop`, one duplication finding addressed (shared `GatewayIdentity` base model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPequenavcKf9xCuENuMWG