### PR TITLE
Fix webhook setup crash when a cloudhook already exists

### DIFF
--- a/custom_components/ttlock/webhook.py
+++ b/custom_components/ttlock/webhook.py
@@ -124,10 +124,10 @@ class WebhookHandler:
 
         if cloud.async_active_subscription(self.hass):
             try:
-                return await cloud.async_create_cloudhook(
+                return await cloud.async_get_or_create_cloudhook(
                     self.hass, self.entry.data[CONF_WEBHOOK_ID]
                 )
-            except cloud.CloudNotConnected:
+            except cloud.CloudNotAvailable:
                 return None
         return None
 

--- a/custom_components/ttlock/webhook.py
+++ b/custom_components/ttlock/webhook.py
@@ -119,7 +119,8 @@ class WebhookHandler:
     async def try_generate_cloudhook(self) -> str | None:
         """Create a cloudhook if possible."""
         # deferred: cloud pulls in optional heavy dependencies we don't want to
-        # require at module import time, and this also lets tests mock it easily
+        # require at module import time - this also lets tests stub the whole
+        # module in sys.modules rather than needing the real thing importable
         from homeassistant.components import cloud  # noqa: PLC0415
 
         if cloud.async_active_subscription(self.hass):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,10 +307,10 @@ def mock_cloud(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     stub.async_active_subscription / async_get_or_create_cloudhook.
     """
     stub = types.ModuleType("homeassistant.components.cloud")
-    stub.CloudNotAvailable = CloudNotAvailable  # ty: ignore[unresolved-attribute]
-    stub.CloudNotConnected = CloudNotConnected  # ty: ignore[unresolved-attribute]
-    stub.async_active_subscription = MagicMock(return_value=False)  # ty: ignore[unresolved-attribute]
-    stub.async_get_or_create_cloudhook = AsyncMock()  # ty: ignore[unresolved-attribute]
+    stub.CloudNotAvailable = CloudNotAvailable  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.CloudNotConnected = CloudNotConnected  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.async_active_subscription = MagicMock(return_value=False)  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.async_get_or_create_cloudhook = AsyncMock()  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
 
     monkeypatch.setitem(sys.modules, "homeassistant.components.cloud", stub)
     monkeypatch.setattr(ha_components, "cloud", stub, raising=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 """Global fixtures for ttlock integration."""
 
-from collections.abc import Generator
+import sys
 from time import time
+import types
 from typing import NamedTuple
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientSession
 import pytest
@@ -22,11 +23,13 @@ from custom_components.ttlock.models import (
     Sensor,
 )
 from custom_components.ttlock.store import LockStateStore
+from homeassistant import components as ha_components
 from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from .const import (
@@ -283,13 +286,33 @@ def mock_api_responses(monkeypatch, mock_data_factory):
     return create_mock_responses
 
 
+class CloudNotAvailable(HomeAssistantError):
+    """Stand-in for homeassistant.components.cloud.CloudNotAvailable."""
+
+
+class CloudNotConnected(CloudNotAvailable):
+    """Stand-in for homeassistant.components.cloud.CloudNotConnected."""
+
+
 @pytest.fixture(autouse=True)
-def mock_webhook_cloudhook() -> Generator[None]:
-    """Fixture to mock home assistant cloud."""
-    with (
-        patch(
-            "custom_components.ttlock.webhook.WebhookHandler.try_generate_cloudhook",
-            return_value=None,
-        ),
-    ):
-        yield
+def mock_cloud(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Stub homeassistant.components.cloud so try_generate_cloudhook actually runs.
+
+    homeassistant.components.cloud is unimportable in this test environment
+    (its import chain drags in camera/turbojpeg, then conversation/hassil),
+    so webhook.py's own deferred import can't be satisfied by the real
+    module. Defaults to no active subscription - the non-cloud path every
+    existing test exercised under the old fixture that patched
+    try_generate_cloudhook directly. Tests wanting the cloud path override
+    stub.async_active_subscription / async_get_or_create_cloudhook.
+    """
+    stub = types.ModuleType("homeassistant.components.cloud")
+    stub.CloudNotAvailable = CloudNotAvailable  # ty: ignore[unresolved-attribute]
+    stub.CloudNotConnected = CloudNotConnected  # ty: ignore[unresolved-attribute]
+    stub.async_active_subscription = MagicMock(return_value=False)  # ty: ignore[unresolved-attribute]
+    stub.async_get_or_create_cloudhook = AsyncMock()  # ty: ignore[unresolved-attribute]
+
+    monkeypatch.setitem(sys.modules, "homeassistant.components.cloud", stub)
+    monkeypatch.setattr(ha_components, "cloud", stub, raising=False)
+
+    return stub

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -291,6 +291,58 @@ class TestGetUrl:
         mock_cloudhook.assert_not_called()
 
 
+class TestTryGenerateCloudhook:
+    async def test_returns_none_without_active_subscription(
+        self, handler: WebhookHandler, mock_cloud
+    ):
+        mock_cloud.async_active_subscription.return_value = False
+
+        assert await handler.try_generate_cloudhook() is None
+        mock_cloud.async_get_or_create_cloudhook.assert_not_called()
+
+    async def test_returns_cloudhook_url_with_active_subscription(
+        self, handler: WebhookHandler, mock_cloud
+    ):
+        mock_cloud.async_active_subscription.return_value = True
+        mock_cloud.async_get_or_create_cloudhook.return_value = (
+            "https://hooks.nabucasa.com/abc"
+        )
+
+        assert (
+            await handler.try_generate_cloudhook() == "https://hooks.nabucasa.com/abc"
+        )
+        mock_cloud.async_get_or_create_cloudhook.assert_awaited_once_with(
+            handler.hass, handler.entry.data[CONF_WEBHOOK_ID]
+        )
+
+    async def test_already_registered_cloudhook_is_not_fatal(
+        self, handler: WebhookHandler, mock_cloud
+    ):
+        """Regression test for #313: a cloudhook already existing for this
+        webhook_id must not raise past try_generate_cloudhook - that's what
+        the old async_create_cloudhook call did, and it failed entry setup.
+        """
+        mock_cloud.async_active_subscription.return_value = True
+        mock_cloud.async_get_or_create_cloudhook.return_value = (
+            "https://hooks.nabucasa.com/existing"
+        )
+
+        assert (
+            await handler.try_generate_cloudhook()
+            == "https://hooks.nabucasa.com/existing"
+        )
+
+    async def test_cloud_not_available_degrades_to_none(
+        self, handler: WebhookHandler, mock_cloud
+    ):
+        mock_cloud.async_active_subscription.return_value = True
+        mock_cloud.async_get_or_create_cloudhook.side_effect = (
+            mock_cloud.CloudNotConnected()
+        )
+
+        assert await handler.try_generate_cloudhook() is None
+
+
 class TestResolveSetupIssue:
     async def test_marks_status_and_resolves_issue(
         self, hass: HomeAssistant, handler: WebhookHandler, entry: MockConfigEntry


### PR DESCRIPTION
## Summary

Closes #313.

`async_create_cloudhook` raises a bare `ValueError` when a cloudhook for the `webhook_id` already exists in cloud prefs, and only `cloud.CloudNotConnected` was caught — so any config entry that lost its stored `CONF_WEBHOOK_URL` while the underlying cloudhook survived (e.g. via the webhook-sharing consolidation added in a67f5be) failed `async_setup_entry` entirely, losing every lock entity for that account. The reporter's locks weren't disabled — they were never created.

- Swap `cloud.async_create_cloudhook` for the idempotent `cloud.async_get_or_create_cloudhook`, which returns the existing URL instead of raising.
- Widen `except cloud.CloudNotConnected` to `except cloud.CloudNotAvailable` (its parent), so a logged-out cloud account degrades the same way a disconnected one already did.
- Replace the autouse test fixture that stubbed our own `try_generate_cloudhook` (meaning the function itself had zero coverage) with one that stubs `homeassistant.components.cloud` in `sys.modules` — necessary because the real module is unimportable in this test env (drags in camera/turbojpeg, then hassil). The real function now executes under test for the first time, including a regression test for this exact failure mode.

Deliberately out of scope, filed separately: making webhook setup failures non-fatal to entry setup in general, webhook-URL staleness once persisted, and cloudhook leaks on integration removal.

## Test plan

- [x] `script/check` (ruff, ty, full pytest suite) passes
- [x] New tests fail against the pre-fix code and pass against the fix (verified via `git stash`)
- [x] `/code-review` run against `develop`, findings addressed (ty-ignore reason clauses, stale comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvyPWXq9s7xw1L3fkphDGc