### PR TITLE
Delete cloudhook on config entry removal

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_WEBHOOK_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
 
@@ -149,3 +150,41 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             domain_data.pop(_STORE_KEY, None)
 
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Delete this entry's cloudhook, once no sibling entry still shares it.
+
+    Sibling config entries under the same client_id share one webhook_id
+    (see webhook.py's module docstring), so deleting on every removal would
+    pull the rug out from under any other entry still using it - checking
+    entry.data[CONF_WEBHOOK_ID] against every other loaded/configured entry
+    (already kept in sync by webhook.py's _sync_entry_to_group) avoids
+    needing this entry's OAuth2 implementation, which may no longer be
+    resolvable this late in removal.
+    """
+    webhook_id = entry.data.get(CONF_WEBHOOK_ID)
+    if webhook_id is None:
+        return
+
+    still_shared = any(
+        candidate.entry_id != entry.entry_id
+        and candidate.data.get(CONF_WEBHOOK_ID) == webhook_id
+        for candidate in hass.config_entries.async_entries(DOMAIN)
+    )
+    if still_shared:
+        return
+
+    # deferred: cloud pulls in optional heavy dependencies we don't want to
+    # require at module import time - matches webhook.py's try_generate_cloudhook
+    from homeassistant.components import cloud  # noqa: PLC0415
+
+    if not cloud.async_active_subscription(hass):
+        return
+
+    # ValueError alongside CloudNotAvailable: hass_nabucasa's Cloudhooks.async_delete
+    # raises a bare ValueError if this webhook_id was never actually converted to a
+    # cloudhook (eg. try_generate_cloudhook returned None despite an active
+    # subscription) - matches mobile_app's async_remove_entry, which hits the same gap.
+    with contextlib.suppress(cloud.CloudNotAvailable, ValueError):
+        await cloud.async_delete_cloudhook(hass, webhook_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,7 @@ def mock_cloud(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     stub.CloudNotConnected = CloudNotConnected  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
     stub.async_active_subscription = MagicMock(return_value=False)  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
     stub.async_get_or_create_cloudhook = AsyncMock()  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.async_delete_cloudhook = AsyncMock()  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
 
     monkeypatch.setitem(sys.modules, "homeassistant.components.cloud", stub)
     monkeypatch.setattr(ha_components, "cloud", stub, raising=False)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -240,3 +240,88 @@ async def test_no_setup_issue_for_entry_joining_confirmed_group(
 
     mock_create.assert_not_called()
     assert entry_b.data[CONF_WEBHOOK_STATUS] is True
+
+
+async def test_removing_last_entry_deletes_cloudhook(
+    hass, component_setup, mock_api_responses, mock_cloud
+):
+    """Removing the sole entry using a webhook_id deletes its cloudhook."""
+    mock_api_responses("default")
+    mock_cloud.async_active_subscription.return_value = True
+    mock_cloud.async_get_or_create_cloudhook.return_value = (
+        "https://hooks.nabucasa.com/abc"
+    )
+
+    await component_setup()
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    webhook_id = entry.data[CONF_WEBHOOK_ID]
+
+    assert await hass.config_entries.async_remove(entry.entry_id)
+
+    mock_cloud.async_delete_cloudhook.assert_awaited_once_with(hass, webhook_id)
+
+
+async def test_removing_one_of_several_shared_entries_keeps_cloudhook(
+    hass, mock_api_responses, mock_cloud, multi_account_credential, new_mocked_entry
+):
+    """Removing one of several entries sharing a webhook_id must not delete it."""
+    mock_api_responses("default")
+    mock_cloud.async_active_subscription.return_value = True
+    mock_cloud.async_get_or_create_cloudhook.return_value = (
+        "https://hooks.nabucasa.com/abc"
+    )
+    await multi_account_credential(hass)
+
+    entry_a = new_mocked_entry()
+    entry_a.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry_a.entry_id)
+
+    entry_b = new_mocked_entry()
+    entry_b.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry_b.entry_id)
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert entry_a.data[CONF_WEBHOOK_ID] == entry_b.data[CONF_WEBHOOK_ID]
+
+    assert await hass.config_entries.async_remove(entry_a.entry_id)
+
+    mock_cloud.async_delete_cloudhook.assert_not_called()
+
+    assert await hass.config_entries.async_remove(entry_b.entry_id)
+
+    mock_cloud.async_delete_cloudhook.assert_awaited_once()
+
+
+async def test_removing_entry_without_cloudhook_is_a_noop(
+    hass, component_setup, mock_api_responses, mock_cloud
+):
+    """Removal is a no-op, not an error, for a non-cloud user."""
+    mock_api_responses("default")
+
+    await component_setup()
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    assert await hass.config_entries.async_remove(entry.entry_id)
+
+    mock_cloud.async_delete_cloudhook.assert_not_called()
+
+
+async def test_removing_entry_whose_cloudhook_was_never_created_is_a_noop(
+    hass, component_setup, mock_api_responses, mock_cloud
+):
+    """Removal is a no-op, not an error, for a cloud user whose webhook_id was
+    never actually converted to a cloudhook (eg. try_generate_cloudhook
+    returned None despite an active subscription) - hass_nabucasa's
+    Cloudhooks.async_delete raises a bare ValueError for this, not
+    cloud.CloudNotAvailable.
+    """
+    mock_api_responses("default")
+    mock_cloud.async_active_subscription.return_value = True
+    mock_cloud.async_delete_cloudhook.side_effect = ValueError(
+        "Hook is not enabled for the cloud."
+    )
+
+    await component_setup()
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    assert await hass.config_entries.async_remove(entry.entry_id)


### PR DESCRIPTION
## Summary
- `async_remove_entry` now calls `cloud.async_delete_cloudhook` when a TTLock config entry is removed, closing a permanent leak in Nabu Casa cloud prefs for cloud users
- Checks that no sibling config entry still shares the removed entry's `webhook_id` (entries can share one webhook per developer application, see `docs/adr/0002-shared-webhook-per-developer-application.md`) before deleting
- Suppresses `ValueError` alongside `cloud.CloudNotAvailable`, since `hass_nabucasa` raises a bare `ValueError` when the webhook_id was never actually converted to a cloudhook — same gap HA core's `mobile_app` integration already works around

Fixes #316

## Test plan
- [x] `script/check` passes (lint, type-check, 251 tests)
- [x] New tests cover all three acceptance criteria: last-entry-sharing removal deletes the cloudhook, removal of one of several sharing entries does not, and removal is a no-op (not an error) both for non-cloud users and for cloud users whose webhook was never converted to a cloudhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvyPWXq9s7xw1L3fkphDGc