### PR TITLE
Allow manually removing orphaned lock/gateway devices

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_WEBHOOK_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .api import TTLockApi
 from .capture import LockTrafficCapture
@@ -150,6 +151,31 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             domain_data.pop(_STORE_KEY, None)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Allow manually deleting a lock/gateway device once it's gone from the account.
+
+    A lock or gateway removed from the TTLock account drops out of
+    async_setup_entry's next get_locks()/get_gateways() call, but its device
+    stays behind in the registry with no entities - the only way to clear it
+    is a manual delete from the device page. Block that for macs still
+    present in this entry's live coordinators (a still-active device HA would
+    just recreate); allow it otherwise, including when this entry's runtime
+    data isn't in hass.data at all (failed/unloaded entry - nothing to check
+    against, and exactly when stale devices are likely to need clearing).
+    """
+    domain_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if domain_data is None:
+        return True
+
+    known_macs = {coordinator.data.mac for coordinator in domain_data[TT_LOCKS]}
+    gateways = domain_data[TT_GATEWAYS].data or {}
+    known_macs.update(gateway.mac for gateway in gateways.values())
+
+    return not any((DOMAIN, mac) in device_entry.identifiers for mac in known_macs)
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from custom_components.ttlock import async_remove_config_entry_device
 from custom_components.ttlock.capture import LockTrafficCapture
 from custom_components.ttlock.const import (
     CONF_WEBHOOK_STATUS,
@@ -9,10 +10,11 @@ from custom_components.ttlock.const import (
     TT_CAPTURE,
     TT_LOCKS,
 )
-from custom_components.ttlock.models import LockSummary
+from custom_components.ttlock.models import Gateway, LockSummary
 from custom_components.ttlock.webhook import WebhookHandler
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_WEBHOOK_ID, EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.network import NoURLAvailableError
 
 
@@ -304,6 +306,87 @@ async def test_removing_entry_without_cloudhook_is_a_noop(
     assert await hass.config_entries.async_remove(entry.entry_id)
 
     mock_cloud.async_delete_cloudhook.assert_not_called()
+
+
+async def test_remove_config_entry_device_blocks_active_lock(
+    hass, component_setup, mock_api_responses
+):
+    """A device for a lock still on the account can't be manually deleted."""
+    mock_api_responses("default")
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    device = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, "16:72:4C:CC:01:C4")}
+    )
+    assert device is not None
+
+    assert await async_remove_config_entry_device(hass, entry, device) is False
+
+
+async def test_remove_config_entry_device_allows_removed_lock(
+    hass, component_setup, mock_api_responses
+):
+    """A device left behind after its lock was removed from the account can be deleted."""
+    mock_api_responses("default")
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    orphaned_device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "00:00:00:00:00:99")},
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, orphaned_device) is True
+
+
+async def test_remove_config_entry_device_blocks_active_gateway(
+    hass, component_setup, mock_api_responses, monkeypatch
+):
+    """A device for a gateway still on the account can't be manually deleted."""
+    mock_api_responses("default")
+
+    async def mock_get_gateways(*args, **kwargs):
+        return [
+            Gateway(
+                gatewayId=1,
+                gatewayName="Test Gateway",
+                gatewayMac="11:22:33:44:55:66",
+                isOnline=True,
+            )
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_gateways", mock_get_gateways
+    )
+
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    gateway_device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "11:22:33:44:55:66")},
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, gateway_device) is False
+
+
+async def test_remove_config_entry_device_allows_when_entry_data_missing(
+    hass, component_setup, mock_api_responses
+):
+    """A failed/unloaded entry has nothing to check against, so removal is allowed."""
+    mock_api_responses("default")
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    device = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, "16:72:4C:CC:01:C4")}
+    )
+    assert device is not None
+
+    hass.data[DOMAIN].pop(entry.entry_id)
+
+    assert await async_remove_config_entry_device(hass, entry, device) is True
 
 
 async def test_removing_entry_whose_cloudhook_was_never_created_is_a_noop(


### PR DESCRIPTION
## Summary
- A lock or gateway removed from the TTLock account drops out of the next `get_locks()`/`get_gateways()` call, but its device stays behind in HA's registry as an unavailable, entity-less orphan with no way to delete it.
- Implements `async_remove_config_entry_device` so the device can be manually deleted from HA's device page, guarded so a lock/gateway that's still active on the account can't be removed by mistake (it would just be recreated on the next reload).
- Applies to both lock and gateway devices. Missing runtime data (failed/unloaded entry) allows removal, since there's nothing to check against and that's plausibly when a user is pruning stale devices anyway.

Closes #114

## Test plan
- [x] `script/check` passes (lint, type-check, full suite)
- [x] New tests cover: active lock blocked, orphaned lock allowed, active gateway blocked, missing entry data allowed
- [ ] Manual verification in a live HA instance (not done — no real TTLock account in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qps3xgXbFK1fcxd4ZeRgZY