### PR TITLE
Add selectable EU/China region support

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -14,7 +14,15 @@ from homeassistant.helpers.device_registry import DeviceEntry
 
 from .api import TTLockApi
 from .capture import LockTrafficCapture
-from .const import DOMAIN, TT_API, TT_CAPTURE, TT_GATEWAYS, TT_LOCKS
+from .const import (
+    CONF_REGION,
+    DEFAULT_REGION,
+    DOMAIN,
+    TT_API,
+    TT_CAPTURE,
+    TT_GATEWAYS,
+    TT_LOCKS,
+)
 from .coordinator import GatewaysUpdateCoordinator, LockUpdateCoordinator
 from .services import Services
 from .store import LockStateStore
@@ -86,7 +94,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         store = LockStateStore(hass)
         domain_data[_STORE_KEY] = store
 
-    client = TTLockApi(aiohttp_client.async_get_clientsession(hass), session, capture)
+    client = TTLockApi(
+        aiohttp_client.async_get_clientsession(hass),
+        session,
+        capture,
+        region=entry.data.get(CONF_REGION, DEFAULT_REGION),
+    )
 
     domain_data[entry.entry_id] = {
         TT_API: client,

--- a/custom_components/ttlock/api.py
+++ b/custom_components/ttlock/api.py
@@ -3,14 +3,17 @@
 This integration talks to TTLock's cloud API, not the locks directly — locks
 connect via a TTLock gateway or WiFi, and the gateway/lock relays commands
 from TTLock's cloud. Full API docs: docs/ttlock-cloud-api/ (mirrored from
-https://euopen.ttlock.com/document; EU region — hardcoded to
-https://euapi.ttlock.com, no multi-region support).
+https://euopen.ttlock.com/document). TTLock runs separate per-region clouds
+(EU/International euapi.ttlock.com, China cnapi.ttlock.com); the region is
+chosen in the config flow and selects TTLockApi's base host (const.REGIONS,
+keyed off entry.data[CONF_REGION], defaulting to EU).
 
 Auth is OAuth2, wired up through HA's application_credentials component
 (application_credentials.py, config_flow.py), but TTLock's OAuth2 is
 non-standard: the initial grant is username + MD5-hashed password
 (TTLockAuthImplementation.login), not an authorization-code redirect. Token
-endpoint: https://euapi.ttlock.com/oauth2/token (const.OAUTH2_TOKEN). Docs:
+endpoint: <host>/oauth2/token, region-specific (const.REGIONS[...]["token_url"],
+built in application_credentials.async_get_auth_implementation). Docs:
 docs/ttlock-cloud-api/oauth2/getAccessToken.md (mirrored from
 https://euopen.ttlock.com/document/doc?urlName=cloud%2Foauth2%2FgetAccessTokenEn.html)
 
@@ -39,7 +42,7 @@ from homeassistant.components.application_credentials import AuthImplementation
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .capture import LockTrafficCapture, log_and_capture
-from .const import get_device_logger
+from .const import DEFAULT_REGION, REGIONS, get_device_logger
 from .models import (
     AddPasscodeConfig,
     Card,
@@ -103,18 +106,18 @@ class TTLockAuthImplementation(
 class TTLockApi:
     """Provide TTLock authentication tied to an OAuth2 based config entry."""
 
-    BASE = "https://euapi.ttlock.com/v3/"
-
     def __init__(
         self,
         websession: ClientSession,
         oauth_session: config_entry_oauth2_flow.OAuth2Session,
         capture: LockTrafficCapture | None = None,
+        region: str = DEFAULT_REGION,
     ) -> None:
         """Initialize TTLock auth."""
         self._web_session = websession
         self._oauth_session = oauth_session
         self._capture = capture
+        self._base = REGIONS[region]["api_base"]
 
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
@@ -189,7 +192,7 @@ class TTLockApi:
         lock_id = kwargs.get("lockId")
         logger = self._logger_for(kwargs)
 
-        url = urljoin(self.BASE, path)
+        url = urljoin(self._base, path)
         self._debug(
             logger,
             lock_id,
@@ -211,7 +214,7 @@ class TTLockApi:
         lock_id = kwargs.get("lockId")
         logger = self._logger_for(kwargs)
 
-        url = urljoin(self.BASE, path)
+        url = urljoin(self._base, path)
         self._debug(
             logger,
             lock_id,

--- a/custom_components/ttlock/application_credentials.py
+++ b/custom_components/ttlock/application_credentials.py
@@ -5,22 +5,37 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_oauth2_flow
 
 from .api import TTLockAuthImplementation
-from .const import OAUTH2_TOKEN
+from .const import CONF_REGION, DEFAULT_REGION, DOMAIN, REGIONS
+
+
+def _region_for_auth_domain(hass: HomeAssistant, auth_domain: str) -> str:
+    """Recover the region a stored credential belongs to.
+
+    application_credentials rebuilds the implementation from the credential
+    alone - it passes no config entry and no region - so region is read back
+    from the entry that uses this credential (region is 1:1 with a TTLock
+    developer app / clientId). Entries created before region support, and
+    credentials with no entry yet (mid config-flow), default to EU.
+    """
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.data.get("auth_implementation") == auth_domain:
+            return entry.data.get(CONF_REGION, DEFAULT_REGION)
+    return DEFAULT_REGION
 
 
 async def async_get_auth_implementation(
     hass: HomeAssistant, auth_domain: str, credential: ClientCredential
-) -> config_entry_oauth2_flow.AbstractOAuth2Implementation:
+) -> TTLockAuthImplementation:
     """Return custom auth implementation."""
+    region = _region_for_auth_domain(hass, auth_domain)
     return TTLockAuthImplementation(
         hass,
         auth_domain,
         credential,
         AuthorizationServer(
             authorize_url="",
-            token_url=OAUTH2_TOKEN,
+            token_url=REGIONS[region]["token_url"],
         ),
     )

--- a/custom_components/ttlock/config_flow.py
+++ b/custom_components/ttlock/config_flow.py
@@ -8,8 +8,13 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN
+from .const import CONF_REGION, DEFAULT_REGION, DOMAIN, REGIONS
 
 
 class TTLockAuthFlowHandler(
@@ -18,6 +23,7 @@ class TTLockAuthFlowHandler(
     """Config flow to handle TTLock OAuth2 authentication."""
 
     DOMAIN = DOMAIN
+    _region: str = DEFAULT_REGION
 
     @property
     def logger(self) -> logging.Logger:
@@ -27,10 +33,17 @@ class TTLockAuthFlowHandler(
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Create an entry for auth."""
+        """Select a region and authenticate against that region's cloud."""
         # Flow has been triggered by external data
         errors = {}
         if user_input is not None:
+            self._region = user_input[CONF_REGION]
+            # TTLock runs separate per-region clouds; point the OAuth token
+            # request at the chosen region before logging in. The runtime
+            # implementation is rebuilt from entry.data[CONF_REGION] on setup
+            # (see application_credentials.async_get_auth_implementation), so
+            # this flow-time mutation only needs to hold for login() here.
+            self.flow_impl.token_url = REGIONS[self._region]["token_url"]  # ty: ignore[unresolved-attribute] - flow_impl is a TTLockAuthImplementation
             session = await self.flow_impl.login(  # ty: ignore[unresolved-attribute] - flow_impl is a TTLockAuthImplementation
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )
@@ -44,9 +57,21 @@ class TTLockAuthFlowHandler(
             step_id="auth",
             data_schema=vol.Schema(
                 {
+                    vol.Required(CONF_REGION, default=self._region): SelectSelector(
+                        SelectSelectorConfig(
+                            options=list(REGIONS),
+                            mode=SelectSelectorMode.DROPDOWN,
+                            translation_key="region",
+                        )
+                    ),
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
                 }
             ),
             errors=errors,
         )
+
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
+        """Persist the selected region alongside the OAuth token."""
+        data[CONF_REGION] = self._region
+        return await super().async_oauth_create_entry(data)

--- a/custom_components/ttlock/const.py
+++ b/custom_components/ttlock/const.py
@@ -8,9 +8,29 @@ TT_LOCKS = "locks"
 TT_GATEWAYS = "gateways"
 TT_CAPTURE = "capture"
 
-OAUTH2_TOKEN = "https://euapi.ttlock.com/oauth2/token"
 CONF_WEBHOOK_URL = "webhook_url"
 CONF_WEBHOOK_STATUS = "webhook_status"
+
+# TTLock runs separate, non-interoperable clouds per region: only the host
+# differs - the /v3/ API paths, /oauth2/token endpoint and the
+# clientId/accessToken/date auth scheme are identical (see issue #319).
+# Region is chosen in the config flow and stored in entry.data[CONF_REGION];
+# entries created before region support have no such key and are treated as
+# "eu" (DEFAULT_REGION), preserving the historic hardcoded-EU behaviour.
+CONF_REGION = "region"
+DEFAULT_REGION = "eu"
+# Option labels live in translations (selector.region.options) - keep this
+# to endpoints only.
+REGIONS: dict[str, dict[str, str]] = {
+    "eu": {
+        "api_base": "https://euapi.ttlock.com/v3/",
+        "token_url": "https://euapi.ttlock.com/oauth2/token",
+    },
+    "cn": {
+        "api_base": "https://cnapi.ttlock.com/v3/",
+        "token_url": "https://cnapi.ttlock.com/oauth2/token",
+    },
+}
 
 SIGNAL_NEW_DATA = f"{DOMAIN}.data_received"
 

--- a/custom_components/ttlock/translations/en.json
+++ b/custom_components/ttlock/translations/en.json
@@ -17,12 +17,24 @@
         "title": "Login to TTLock",
         "description": "Please provide the login details that you used to log into the TTLock app when setting up your locks",
         "data": {
+          "region": "Region",
           "password": "Password",
           "username": "Username"
+        },
+        "data_description": {
+          "region": "The TTLock cloud your account and developer app are registered with. EU / International covers everywhere except mainland China."
         }
       },
       "pick_implementation": {
         "title": "Pick Authentication Method"
+      }
+    }
+  },
+  "selector": {
+    "region": {
+      "options": {
+        "eu": "EU / International",
+        "cn": "China"
       }
     }
   },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -129,6 +129,35 @@ class TestGetAndPost:
         with pytest.raises(RequestFailed):
             await ttlock_api.get("lock/detail", lockId=1)
 
+    async def test_region_selects_api_base_host(
+        self, mock_oauth_session, mocker: AiohttpClientMocker
+    ):
+        """The China region routes requests to cnapi instead of euapi."""
+        session = mocker.create_session(None)
+        cn_api = TTLockApi(session, mock_oauth_session, region="cn")
+        mocker.get(
+            "https://cnapi.ttlock.com/v3/lock/detail", json={"errcode": 0, "lockId": 1}
+        )
+
+        res = await cn_api.get("lock/detail", lockId=1)
+
+        assert res == {"errcode": 0, "lockId": 1}
+        assert str(mocker.mock_calls[0][1]).startswith("https://cnapi.ttlock.com/v3/")
+        await session.close()
+
+    async def test_region_defaults_to_eu(
+        self, mock_oauth_session, mocker: AiohttpClientMocker
+    ):
+        """Omitting region preserves the historic EU host."""
+        session = mocker.create_session(None)
+        eu_api = TTLockApi(session, mock_oauth_session)
+        mocker.get(f"{BASE}lock/detail", json={"errcode": 0, "lockId": 1})
+
+        await eu_api.get("lock/detail", lockId=1)
+
+        assert str(mocker.mock_calls[0][1]).startswith(BASE)
+        await session.close()
+
 
 class TestPerLockLogging:
     async def test_debug_on_one_lock_logger_does_not_capture_another_locks_records(

--- a/tests/test_application_credentials.py
+++ b/tests/test_application_credentials.py
@@ -1,0 +1,47 @@
+"""Test region-aware OAuth implementation wiring."""
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ttlock.application_credentials import (
+    async_get_auth_implementation,
+)
+from custom_components.ttlock.const import CONF_REGION, DOMAIN
+from homeassistant.components.application_credentials import ClientCredential
+from homeassistant.core import HomeAssistant
+
+CREDENTIAL = ClientCredential("client-id", "client-secret")
+EU_TOKEN = "https://euapi.ttlock.com/oauth2/token"
+CN_TOKEN = "https://cnapi.ttlock.com/oauth2/token"
+
+
+def _entry(hass: HomeAssistant, **data) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={"auth_implementation": "mocked", **data}
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_token_url_follows_china_region(hass: HomeAssistant):
+    """A config entry stored with the China region yields the cnapi token URL."""
+    _entry(hass, **{CONF_REGION: "cn"})
+
+    impl = await async_get_auth_implementation(hass, "mocked", CREDENTIAL)
+
+    assert impl.token_url == CN_TOKEN
+
+
+async def test_legacy_entry_without_region_defaults_to_eu(hass: HomeAssistant):
+    """Entries created before region support (no region key) stay on euapi."""
+    _entry(hass)
+
+    impl = await async_get_auth_implementation(hass, "mocked", CREDENTIAL)
+
+    assert impl.token_url == EU_TOKEN
+
+
+async def test_no_matching_entry_defaults_to_eu(hass: HomeAssistant):
+    """A credential with no config entry yet (mid-flight) defaults to euapi."""
+    impl = await async_get_auth_implementation(hass, "orphan", CREDENTIAL)
+
+    assert impl.token_url == EU_TOKEN

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,73 @@
+"""Test the TTLock config flow region selection."""
+
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.ttlock.api import TTLockAuthImplementation
+from custom_components.ttlock.const import CONF_REGION, DOMAIN
+from homeassistant import config_entries
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
+
+TOKEN = {
+    "access_token": "access",
+    "refresh_token": "refresh",
+    "expires_in": 7776000,
+    "token_type": "Bearer",
+    "scope": "",
+}
+
+
+@pytest.mark.parametrize(
+    ("region", "token_url"),
+    [
+        ("eu", "https://euapi.ttlock.com/oauth2/token"),
+        ("cn", "https://cnapi.ttlock.com/oauth2/token"),
+    ],
+)
+async def test_flow_persists_region_and_targets_its_token_url(
+    hass: HomeAssistant, region: str, token_url: str
+):
+    """Selecting a region persists it and points login at that region's cloud."""
+    assert await async_setup_component(hass, "application_credentials", {})
+    await async_import_client_credential(
+        hass, DOMAIN, ClientCredential("client-id", "client-secret"), "mocked"
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    if result["step_id"] == "pick_implementation":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"implementation": "mocked"}
+        )
+    assert result["step_id"] == "auth"
+    captured: dict[str, str] = {}
+
+    async def fake_token_request(self: TTLockAuthImplementation, data: dict) -> dict:
+        captured["token_url"] = self.token_url
+        return dict(TOKEN)
+
+    with (
+        patch.object(TTLockAuthImplementation, "_token_request", fake_token_request),
+        patch("custom_components.ttlock.async_setup_entry", return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_REGION: region,
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_REGION] == region
+    assert captured["token_url"] == token_url


### PR DESCRIPTION
Closes #319

## What

TTLock runs separate, non-interoperable clouds per region (EU `euapi.ttlock.com`, China `cnapi.ttlock.com`). Only the host differs — the `/v3/` API paths, `/oauth2/token` endpoint, and the `clientId`/`accessToken`/`date` auth scheme are identical. Previously the integration hardcoded the EU host for **both** the API base and the OAuth token endpoint, so China-region users had to patch source.

This makes the region selectable in the config flow (issue #319's recommended option 2), a single codebase serving both regions.

## How

- **`const.REGIONS`** is the single source of truth mapping each region key (`eu`/`cn`) to its `api_base` and `token_url`. The old `OAUTH2_TOKEN` constant is removed.
- **`TTLockApi`** takes a `region` and selects its base host per request.
- **`application_credentials.async_get_auth_implementation`** recovers the region from the config entry that uses the credential (region is 1:1 with a TTLock developer app / `clientId`) to build the region-specific `token_url`. This is required because HA rebuilds the OAuth implementation from the stored credential with no region argument — so token refresh after a restart still hits the correct cloud.
- **`config_flow`** adds a region dropdown, points the OAuth token request at the chosen region before `login()`, and persists the region on the entry via `async_oauth_create_entry`. Option labels are localized via `translation_key` (`selector.region.options` in `en.json`).

## Compatibility

Entries created before region support have no `region` key and default to **EU** everywhere it's read — existing installs are unchanged, no migration needed. Webhook handling is untouched (push is region-agnostic; the callback URL is set per developer app at the global console).

## Verification

- New tests: region selects API base (`test_api.py`), region read-back → `token_url` including legacy/orphan defaults (`test_application_credentials.py`), config flow persists region and targets its `token_url` for both EU and CN (`test_config_flow.py`).
- Full suite: 262 passing. `ty` clean. pre-commit (ruff check/format, codespell, ty) clean.

> Note: verified unit-level + EU regression only — I have no China `cnapi` account. The live China path rests on the reporter's end-to-end confirmation in #319 (`errcode: 0`, `gateway/list` HTTP 200, webhook `success: True`).
