### PR TITLE
Reduce cloud API usage with tiered, configurable polling

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -47,6 +47,10 @@ _CAPTURE_KEY = "_capture"
 # per-account state.
 _STORE_KEY = "_lock_state_store"
 
+# Per-entry key holding the options snapshot the coordinators were built with,
+# so _reload_on_options_update can ignore non-options entry updates.
+_OPTIONS_KEY = "_options_snapshot"
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -83,6 +87,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
 
+    # Re-create coordinators with the new cadence when polling options change.
+    entry.async_on_unload(entry.add_update_listener(_reload_on_options_update))
+
     domain_data = hass.data.setdefault(DOMAIN, {})
     capture = domain_data.get(_CAPTURE_KEY)
     if capture is None:
@@ -104,6 +111,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     domain_data[entry.entry_id] = {
         TT_API: client,
         TT_CAPTURE: capture,
+        # Snapshot of the options the coordinators below were built with, so
+        # the update listener can tell a real options change from the entry.data
+        # writes webhook.py makes during setup (which must not trigger a reload).
+        _OPTIONS_KEY: dict(entry.options),
     }
 
     locks = [
@@ -146,6 +157,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     return True
+
+
+async def _reload_on_options_update(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the entry when its options change, so coordinators pick them up.
+
+    HA fires this listener on any entry update, including the entry.data writes
+    webhook.py makes during setup - reload only when the options themselves
+    actually changed, or those writes would trigger a reload storm mid-setup.
+    """
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    # No snapshot yet (update fired before setup finished storing it, or the
+    # entry isn't loaded) - not a real options change, so don't reload.
+    if entry_data is None or entry_data.get(_OPTIONS_KEY) == dict(entry.options):
+        return
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/ttlock/config_flow.py
+++ b/custom_components/ttlock/config_flow.py
@@ -5,16 +5,33 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
 )
 
-from .const import CONF_REGION, DEFAULT_REGION, DOMAIN, REGIONS
+from .const import (
+    CONF_POLL_INTERVAL,
+    CONF_REGION,
+    CONF_SLOW_POLL_INTERVAL,
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    DEFAULT_REGION,
+    DEFAULT_SLOW_POLL_INTERVAL_HOURS,
+    DOMAIN,
+    REGIONS,
+)
 
 
 class TTLockAuthFlowHandler(
@@ -75,3 +92,73 @@ class TTLockAuthFlowHandler(
         """Persist the selected region alongside the OAuth token."""
         data[CONF_REGION] = self._region
         return await super().async_oauth_create_entry(data)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Get the options flow for tuning polling cadence."""
+        return TTLockOptionsFlow()
+
+
+class TTLockOptionsFlow(OptionsFlow):
+    """Let users tune how often the integration polls the TTLock cloud.
+
+    Two knobs, both global to the account entry: the fast poll interval that
+    re-verifies lock state, and the slow interval that governs how often
+    detail/passage/gateway data is re-fetched (see coordinator.py). Defaults
+    are gentle because webhooks carry real-time changes; users whose webhooks
+    are unreliable can dial the fast interval back down. Changing either
+    reloads the entry so new coordinators pick the values up.
+    """
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the polling-cadence options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        options = self.config_entry.options
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_POLL_INTERVAL,
+                        default=options.get(
+                            CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL_MINUTES
+                        ),
+                    ): vol.All(
+                        NumberSelector(
+                            NumberSelectorConfig(
+                                min=5,
+                                max=1440,
+                                step=1,
+                                unit_of_measurement="minutes",
+                                mode=NumberSelectorMode.BOX,
+                            )
+                        ),
+                        # NumberSelector yields floats; keep stored options as
+                        # ints so the reload guard's snapshot compares cleanly.
+                        vol.Coerce(int),
+                    ),
+                    vol.Required(
+                        CONF_SLOW_POLL_INTERVAL,
+                        default=options.get(
+                            CONF_SLOW_POLL_INTERVAL, DEFAULT_SLOW_POLL_INTERVAL_HOURS
+                        ),
+                    ): vol.All(
+                        NumberSelector(
+                            NumberSelectorConfig(
+                                min=1,
+                                max=168,
+                                step=1,
+                                unit_of_measurement="hours",
+                                mode=NumberSelectorMode.BOX,
+                            )
+                        ),
+                        vol.Coerce(int),
+                    ),
+                }
+            ),
+        )

--- a/custom_components/ttlock/const.py
+++ b/custom_components/ttlock/const.py
@@ -32,6 +32,18 @@ REGIONS: dict[str, dict[str, str]] = {
     },
 }
 
+# Polling cadence, tunable via the options flow (see config_flow.py).
+# The fast tier re-verifies lock state (locked/opened) every poll; the slow
+# tier refreshes rarely-changing detail (battery, name, autolock/sound config,
+# passage-mode config, gateway link) only once per slow interval. Webhooks
+# (webhook.py) carry real-time changes, so the poll is mostly reconciliation -
+# these defaults are deliberately gentler than the historic 15-minute loop to
+# keep multi-lock accounts under TTLock's free-tier API-call budget (#320).
+CONF_POLL_INTERVAL = "poll_interval"
+CONF_SLOW_POLL_INTERVAL = "slow_poll_interval"
+DEFAULT_POLL_INTERVAL_MINUTES = 30
+DEFAULT_SLOW_POLL_INTERVAL_HOURS = 6
+
 SIGNAL_NEW_DATA = f"{DOMAIN}.data_received"
 
 DEVICE_LOGGER_PREFIX = f"{__package__}.device."

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -30,7 +30,16 @@ from homeassistant.util import dt as dt_util
 
 from .api import TTLockApi
 from .capture import LockTrafficCapture
-from .const import DOMAIN, SIGNAL_NEW_DATA, TT_GATEWAYS, TT_LOCKS
+from .const import (
+    CONF_POLL_INTERVAL,
+    CONF_SLOW_POLL_INTERVAL,
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    DEFAULT_SLOW_POLL_INTERVAL_HOURS,
+    DOMAIN,
+    SIGNAL_NEW_DATA,
+    TT_GATEWAYS,
+    TT_LOCKS,
+)
 from .models import (
     Features,
     Gateway,
@@ -230,12 +239,29 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         # persisted, so it naturally resets to False on every restart.
         self._sensor_recheck_done = False
 
+        # Slow-tier cadence and its per-call "last fetched" gates. Only lock
+        # state is re-verified every poll; detail/passage/gateway fetches run
+        # at most once per _slow_interval (see _async_update_data). Timestamps
+        # are in-memory, so a restart re-fetches everything once - which is
+        # what we want on startup anyway.
+        options = config_entry.options if config_entry else {}
+        poll_minutes = options.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL_MINUTES)
+        slow_hours = options.get(
+            CONF_SLOW_POLL_INTERVAL, DEFAULT_SLOW_POLL_INTERVAL_HOURS
+        )
+        self._slow_interval = timedelta(hours=slow_hours)
+        self._details_last_fetched: datetime | None = None
+        self._passage_last_fetched: datetime | None = None
+        self._gateways_last_fetched: datetime | None = None
+
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             config_entry=config_entry,
-            update_interval=timedelta(minutes=15) if self.connectable else None,
+            update_interval=(
+                timedelta(minutes=poll_minutes) if self.connectable else None
+            ),
         )
 
         self.data = LockState(
@@ -251,18 +277,26 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             )
 
         try:
-            details = await self.api.get_lock(self.lock_id)
-
+            now = dt_util.now()
             new_data = deepcopy(self.data)
 
-            # update mutable attributes
-            new_data.name = details.name
-            new_data.mac = details.mac
-            new_data.model = details.model
-            new_data.features = Features.from_feature_value(details.featureValue)
-            new_data.battery_level = details.battery_level
-            new_data.hardware_version = details.hardwareRevision
-            new_data.firmware_version = details.firmwareRevision
+            # Slow tier: full lock detail (battery, name, model, features,
+            # autolock/sound config). Slow-changing and, for lock/unlock,
+            # already delivered in real time by webhooks - so fetch it at most
+            # once per slow interval and otherwise carry the previous values
+            # forward via the deepcopy above.
+            if self._slow_tier_due(self._details_last_fetched, now):
+                details = await self.api.get_lock(self.lock_id)
+                new_data.name = details.name
+                new_data.mac = details.mac
+                new_data.model = details.model
+                new_data.features = Features.from_feature_value(details.featureValue)
+                new_data.battery_level = details.battery_level
+                new_data.hardware_version = details.hardwareRevision
+                new_data.firmware_version = details.firmwareRevision
+                new_data.auto_lock_seconds = details.autoLockTime
+                new_data.lock_sound = bool(details.lockSound)
+                self._details_last_fetched = now
 
             if Features.door_sensor in new_data.features:
                 # make sure we have a placeholder for sensor state if the lock supports it
@@ -276,6 +310,8 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             else:
                 new_data.sensor = None
 
+            # Fast tier: re-verify lock (and door) state every poll - this is
+            # the real-time-relevant signal and the reason the poll exists.
             try:
                 state = await self.api.get_lock_state(self.lock_id)
                 new_data.locked = state.locked == State.locked
@@ -293,21 +329,34 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
                         f"Failed to re-verify lock state for {self.lock_id}"
                     ) from err
 
-            new_data.auto_lock_seconds = details.autoLockTime
-            new_data.lock_sound = bool(details.lockSound)
+            # Slow tier: passage-mode schedule config, rarely changes.
+            if self._slow_tier_due(self._passage_last_fetched, now):
+                new_data.passage_mode_config = (
+                    await self.api.get_lock_passage_mode_config(self.lock_id)
+                )
+                self._passage_last_fetched = now
 
-            new_data.passage_mode_config = await self.api.get_lock_passage_mode_config(
-                self.lock_id
-            )
-
+            # Slow tier: gateway link (RSSI/name/mac for the signal sensor).
             if self.has_gateway:
-                new_data.gateways = await self.api.get_gateways_for_lock(self.lock_id)
+                if self._slow_tier_due(self._gateways_last_fetched, now):
+                    new_data.gateways = await self.api.get_gateways_for_lock(
+                        self.lock_id
+                    )
+                    self._gateways_last_fetched = now
             else:
                 new_data.gateways = []
         except Exception as err:
             raise UpdateFailed(err) from err
         else:
             return new_data
+
+    def _slow_tier_due(self, last_fetched: datetime | None, now: datetime) -> bool:
+        """Whether a slow-tier fetch is due, given when it last ran.
+
+        Due if never fetched (None - e.g. first poll after a restart) or if
+        the slow interval has elapsed since the last fetch.
+        """
+        return last_fetched is None or last_fetched <= now - self._slow_interval
 
     async def _refresh_sensor(self, sensor: SensorData) -> Sensor | None:
         """Query the door sensor endpoint and stamp when we last did so."""

--- a/custom_components/ttlock/translations/en.json
+++ b/custom_components/ttlock/translations/en.json
@@ -30,6 +30,22 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Polling cadence",
+        "description": "How often the integration polls the TTLock cloud. Locks also update in near real time via webhooks, so these can stay high to keep multi-lock accounts under TTLock's free-tier API-call limit. Lower the poll interval if your webhooks are unreliable.",
+        "data": {
+          "poll_interval": "Poll interval",
+          "slow_poll_interval": "Detail refresh interval"
+        },
+        "data_description": {
+          "poll_interval": "How often to re-check whether each lock is locked or unlocked, in minutes.",
+          "slow_poll_interval": "How often to refresh slow-changing detail (battery, name, autolock and passage-mode config, gateway signal), in hours."
+        }
+      }
+    }
+  },
   "selector": {
     "region": {
       "options": {
@@ -48,7 +64,7 @@
       "title": "Confirm your TTLock webhook URL"
     },
     "webhook_setup": {
-      "description": "TTLock won't push updates until this webhook URL is registered with your developer application:\n\n{webhook_url}\n\nUse the link below to open the TTLock console, or see [the setup docs]({docs_url}) for more info. Until this is done, locks still stay in sync via TTLock's regular 15-minute poll.",
+      "description": "TTLock won't push updates until this webhook URL is registered with your developer application:\n\n{webhook_url}\n\nUse the link below to open the TTLock console, or see [the setup docs]({docs_url}) for more info. Until this is done, locks still stay in sync via the integration's regular poll.",
       "title": "Register your TTLock webhook URL"
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ ignore = [
     "PLR0911", # Too many return statements ({returns} > {max_returns})
     "PLR0912", # Too many branches ({branches} > {max_branches})
     "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+    "PLR0917", # Too many positional arguments ({c_pos_args} > {max_pos_args})
     "PLR0915", # Too many statements ({statements} > {max_statements})
     "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
     "PLW0108", # Unnecessary lambda wrapping a function call; can often be replaced by the function itself

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,9 +3,15 @@
 from unittest.mock import patch
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ttlock.api import TTLockAuthImplementation
-from custom_components.ttlock.const import CONF_REGION, DOMAIN
+from custom_components.ttlock.const import (
+    CONF_POLL_INTERVAL,
+    CONF_REGION,
+    CONF_SLOW_POLL_INTERVAL,
+    DOMAIN,
+)
 from homeassistant import config_entries
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -71,3 +77,26 @@ async def test_flow_persists_region_and_targets_its_token_url(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_REGION] == region
     assert captured["token_url"] == token_url
+
+
+async def test_options_flow_saves_polling_cadence(hass: HomeAssistant):
+    """The options flow persists the fast/slow polling intervals."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_POLL_INTERVAL: 45, CONF_SLOW_POLL_INTERVAL: 12},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    # coerced to int (NumberSelector yields floats) so the reload guard's
+    # snapshot comparison stays clean
+    assert entry.options[CONF_POLL_INTERVAL] == 45
+    assert isinstance(entry.options[CONF_POLL_INTERVAL], int)
+    assert entry.options[CONF_SLOW_POLL_INTERVAL] == 12
+    assert isinstance(entry.options[CONF_SLOW_POLL_INTERVAL], int)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,9 +8,13 @@ import dateparser
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.ttlock.api import RequestFailed
+from custom_components.ttlock.api import RequestFailed, TTLockApi
 from custom_components.ttlock.capture import LockTrafficCapture
-from custom_components.ttlock.const import DOMAIN
+from custom_components.ttlock.const import (
+    CONF_POLL_INTERVAL,
+    CONF_SLOW_POLL_INTERVAL,
+    DOMAIN,
+)
 from custom_components.ttlock.coordinator import (
     GatewaysUpdateCoordinator,
     LockState,
@@ -442,6 +446,107 @@ class TestLockUpdateCoordinator:
             assert wifi_coordinator.connectable is True
             assert called is False
             assert wifi_coordinator.data.gateways == []
+
+    class TestPollingCadence:
+        """Lock state is re-verified every poll; slow-changing detail,
+        passage-mode config and the gateway link are fetched at most once per
+        slow interval (see coordinator.py _async_update_data). Cadence is
+        driven by the entry's options, defaulting to 30 min / 6 h."""
+
+        @staticmethod
+        def _spy(monkeypatch, name):
+            """Wrap the currently-installed mock for `name` in a call counter."""
+            current = getattr(TTLockApi, name)
+            spy = AsyncMock(side_effect=current)
+            monkeypatch.setattr(f"custom_components.ttlock.api.TTLockApi.{name}", spy)
+            return spy
+
+        def _make_coordinator(self, hass, api, options=None):
+            config_entry = MockConfigEntry(domain=DOMAIN, options=options or {})
+            config_entry.add_to_hass(hass)
+            summary = LockSummary(
+                lockId=7252408,
+                lockAlias="Test Lock",
+                lockMac="00:00:00:00:00:00",
+                hasGateway=1,
+            )
+            return LockUpdateCoordinator(
+                hass,
+                config_entry,
+                api,
+                summary,
+                LockTrafficCapture(),
+                LockStateStore(hass),
+            )
+
+        async def test_defaults_when_no_options(self, hass, api):
+            coordinator = self._make_coordinator(hass, api)
+            assert coordinator.update_interval == timedelta(minutes=30)
+            assert coordinator._slow_interval == timedelta(hours=6)
+
+        async def test_intervals_from_options(self, hass, api):
+            coordinator = self._make_coordinator(
+                hass,
+                api,
+                options={CONF_POLL_INTERVAL: 45, CONF_SLOW_POLL_INTERVAL: 12},
+            )
+            assert coordinator.update_interval == timedelta(minutes=45)
+            assert coordinator._slow_interval == timedelta(hours=12)
+
+        async def test_state_reverified_every_poll_detail_fetched_once(
+            self, coordinator, mock_api_responses, monkeypatch
+        ):
+            mock_api_responses("with_sensor")
+            get_lock = self._spy(monkeypatch, "get_lock")
+            get_state = self._spy(monkeypatch, "get_lock_state")
+            get_passage = self._spy(monkeypatch, "get_lock_passage_mode_config")
+            get_gateways = self._spy(monkeypatch, "get_gateways_for_lock")
+
+            await coordinator.async_refresh()
+            await coordinator.async_refresh()
+            await coordinator.async_refresh()
+
+            # fast tier: every poll
+            assert get_state.call_count == 3
+            # slow tier: once, then gated
+            assert get_lock.call_count == 1
+            assert get_passage.call_count == 1
+            assert get_gateways.call_count == 1
+
+        async def test_slow_tier_refetched_after_interval(
+            self, coordinator, mock_api_responses, monkeypatch
+        ):
+            mock_api_responses("default")
+            get_lock = self._spy(monkeypatch, "get_lock")
+            get_passage = self._spy(monkeypatch, "get_lock_passage_mode_config")
+            get_gateways = self._spy(monkeypatch, "get_gateways_for_lock")
+
+            await coordinator.async_refresh()
+            # simulate the slow interval having elapsed since the last fetch
+            past = dt_util.now() - timedelta(hours=7)
+            coordinator._details_last_fetched = past
+            coordinator._passage_last_fetched = past
+            coordinator._gateways_last_fetched = past
+
+            await coordinator.async_refresh()
+
+            assert get_lock.call_count == 2
+            assert get_passage.call_count == 2
+            assert get_gateways.call_count == 2
+
+        async def test_detail_carried_forward_when_slow_tier_skipped(
+            self, coordinator, mock_api_responses, monkeypatch
+        ):
+            mock_api_responses("default")
+            await coordinator.async_refresh()
+            name = coordinator.data.name
+            battery = coordinator.data.battery_level
+            assert name is not None
+
+            # second poll skips get_lock but must preserve prior detail
+            await coordinator.async_refresh()
+            assert coordinator.data.name == name
+            assert coordinator.data.battery_level == battery
 
     class TestSensorAbsenceTracking:
         """See coordinator.py's _check_for_sensor - the whole reason issue

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,10 +1,13 @@
 """Test ttlock setup process."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from custom_components.ttlock import async_remove_config_entry_device
 from custom_components.ttlock.capture import LockTrafficCapture
 from custom_components.ttlock.const import (
+    CONF_POLL_INTERVAL,
+    CONF_SLOW_POLL_INTERVAL,
     CONF_WEBHOOK_STATUS,
     DOMAIN,
     TT_CAPTURE,
@@ -32,6 +35,28 @@ async def test_setup_unload_and_reload_entry(hass, component_setup, mock_api_res
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     assert entry.state == ConfigEntryState.NOT_LOADED
+
+
+async def test_changing_options_reloads_with_new_interval(
+    hass, component_setup, mock_api_responses
+):
+    """Updating the polling options reloads the entry so coordinators pick up
+    the new cadence (see _reload_on_options_update)."""
+    mock_api_responses("default")
+    await component_setup()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator = hass.data[DOMAIN][entry.entry_id][TT_LOCKS][0]
+    assert coordinator.update_interval == timedelta(minutes=30)
+
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_POLL_INTERVAL: 90, CONF_SLOW_POLL_INTERVAL: 24}
+    )
+    await hass.async_block_till_done()
+
+    # reload rebuilt the coordinators with the new cadence
+    coordinator = hass.data[DOMAIN][entry.entry_id][TT_LOCKS][0]
+    assert coordinator.update_interval == timedelta(minutes=90)
 
 
 async def test_capture_is_shared_across_config_entries(


### PR DESCRIPTION
## Problem

Multi-lock accounts hit TTLock's free-tier cap of 30k API calls/month. The old 15-minute poll fired ~4 calls per lock (`get_lock`, `get_lock_state`, `get_lock_passage_mode_config`, `get_gateways_for_lock`) ≈ **11.5k/lock/month**, so the free tier topped out at ~2.6 locks. Webhooks (`webhook.py`) already deliver real-time state, so most of that poll was redundant reconciliation.

## Change

Split the per-lock poll into two tiers:

- **Fast tier** — re-verifies lock state (`get_lock_state`) every poll; this is the real-time-relevant signal and the reason the poll exists.
- **Slow tier** — refreshes `get_lock` (battery/name/autolock/sound), passage-mode config, and the gateway link at most once per slow interval, carrying prior values forward via the existing `deepcopy`.

Both intervals are tunable via a **new options flow**, defaulting to a gentler **30 min / 6 h** (applied to existing installs too — the whole point is fixing usage for accounts already over budget). Changing them reloads the entry so coordinators pick up the new cadence; the reload listener is guarded by an options snapshot so `webhook.py`'s `entry.data` writes during setup don't trigger a reload storm.

### Impact

A 3-lock account drops from ~34k/month to roughly ~4–5k/month — comfortably under the 30k cap with headroom.

## Follow-ups (not in this PR)

- Eliminate the per-lock gateway call entirely by fetching `gateway/listLock` once per gateway in `GatewaysUpdateCoordinator` (trades N-lock calls for N-gateway calls).
- Optionally couple webhook pushes to reset the fast-poll timer — gated on first confirming the push payload carries everything the reconciliation poll fetches.

## Testing

`script/check` green: lint, types, and **269 passing** tests, including new `TestPollingCadence`, options-flow, and reload coverage.