### PR TITLE
ble: parse lockData from lock/list

### DIFF
--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -96,6 +96,19 @@ class LockSummary(BaseModel):
     featureValue: str | None = None
     hasGateway: int = 0
 
+    # sensitive fields
+    #
+    # lockData is the per-lock credential blob TTLock's own SDK uses to talk
+    # to a lock directly over BLE - it is only ever returned by lock/list
+    # (see docs/ttlock-cloud-api/lock/list.md) and ekey/get, never by
+    # lock/detail. Carrying it here means a future local BLE transport needs
+    # no second authentication path: the developer OAuth2 session this
+    # integration already holds is sufficient. Treated as opaque - it is a
+    # server-issued blob whose contents are TTLock's business, not ours, and
+    # it is mutable (lock/updateLockData is the write-back endpoint). Always
+    # redacted from diagnostics via const.TO_REDACT.
+    lockData: str | None = None
+
     @property
     def features(self) -> "Features":
         """Parse the feature bitmask."""

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -101,10 +101,8 @@ class LockSummary(BaseModel):
     # lockData is the per-lock credential blob TTLock's own SDK uses to talk
     # to a lock directly over BLE - it is only ever returned by lock/list
     # (see docs/ttlock-cloud-api/lock/list.md) and ekey/get, never by
-    # lock/detail. Carrying it here means a future local BLE transport needs
-    # no second authentication path: the developer OAuth2 session this
-    # integration already holds is sufficient. Treated as opaque - it is a
-    # server-issued blob whose contents are TTLock's business, not ours, and
+    # lock/detail.
+    # Treated as opaque - its contents are TTLock's business, not ours, and
     # it is mutable (lock/updateLockData is the write-back endpoint). Always
     # redacted from diagnostics via const.TO_REDACT.
     lockData: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ from .const import (
     LOCK_DETAILS_WITH_SENSOR,
     LOCK_STATE_LOCKED,
     LOCK_STATE_UNLOCKED,
+    MOCK_LOCK_DATA,
     PASSAGE_MODE_6_TO_6_7_DAYS,
     SENSOR_DETAILS,
 )
@@ -230,6 +231,9 @@ def mock_api_responses(monkeypatch, mock_data_factory):
                     lockMac=mock_data.lock.mac,
                     featureValue=mock_data.lock.featureValue,
                     hasGateway=1,
+                    # real lock/list responses always carry this; keep it in the
+                    # fixture so nothing regresses to assuming it is absent.
+                    lockData=MOCK_LOCK_DATA,
                 )
             ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,6 @@ from .const import (
     LOCK_DETAILS_WITH_SENSOR,
     LOCK_STATE_LOCKED,
     LOCK_STATE_UNLOCKED,
-    MOCK_LOCK_DATA,
     PASSAGE_MODE_6_TO_6_7_DAYS,
     SENSOR_DETAILS,
 )
@@ -231,9 +230,8 @@ def mock_api_responses(monkeypatch, mock_data_factory):
                     lockMac=mock_data.lock.mac,
                     featureValue=mock_data.lock.featureValue,
                     hasGateway=1,
-                    # real lock/list responses always carry this; keep it in the
-                    # fixture so nothing regresses to assuming it is absent.
-                    lockData=MOCK_LOCK_DATA,
+                    # opaque binary blob, value doesn't matter to us, just presence
+                    lockData="TW9ja0xvY2tEYXRhQmxvYkZvclRlc3Rz",
                 )
             ]
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -112,9 +112,3 @@ WEBHOOK_SENSOR_CLOSE = {
     "username": "test",
     "success": 1,
 }
-
-# A stand-in for the opaque per-lock BLE credential blob that lock/list
-# returns as lockData. The real value is a server-issued base64 string this
-# integration treats as opaque; the tests only care that it round-trips onto
-# LockSummary and is redacted, so any base64-shaped string will do.
-MOCK_LOCK_DATA = "TW9ja0xvY2tEYXRhQmxvYkZvclRlc3Rz"

--- a/tests/const.py
+++ b/tests/const.py
@@ -112,3 +112,9 @@ WEBHOOK_SENSOR_CLOSE = {
     "username": "test",
     "success": 1,
 }
+
+# A stand-in for the opaque per-lock BLE credential blob that lock/list
+# returns as lockData. The real value is a server-issued base64 string this
+# integration treats as opaque; the tests only care that it round-trips onto
+# LockSummary and is redacted, so any base64-shaped string will do.
+MOCK_LOCK_DATA = "TW9ja0xvY2tEYXRhQmxvYkZvclRlc3Rz"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -9,7 +9,7 @@ from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClien
 
 from custom_components.ttlock.api import TTLockApi
 from custom_components.ttlock.capture import LockTrafficCapture
-from custom_components.ttlock.const import DOMAIN, TT_GATEWAYS, TT_LOCKS
+from custom_components.ttlock.const import DOMAIN, TO_REDACT, TT_GATEWAYS, TT_LOCKS
 from custom_components.ttlock.coordinator import LockUpdateCoordinator
 from custom_components.ttlock.diagnostics import (
     async_get_config_entry_diagnostics,
@@ -17,6 +17,7 @@ from custom_components.ttlock.diagnostics import (
 )
 from custom_components.ttlock.models import Gateway, LockSummary
 from custom_components.ttlock.store import LockStateStore
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -298,3 +299,28 @@ async def test_debug_capture_redaction_does_not_affect_live_log_output(
     assert any("Received response" in message for message in captured_messages)
     assert not any(sensitive_value in message for message in captured_messages)
     assert any("**REDACTED**" in message for message in captured_messages)
+
+
+def test_to_redact_covers_lock_data():
+    """lockData is a per-lock BLE credential blob - it must never survive redaction.
+
+    lock/list is not lock-scoped (no lockId), so its response doesn't reach the
+    per-lock capture buffer today and this is a forward guard rather than a
+    regression test: the moment lockData is carried anywhere that feeds
+    coordinator.as_dict(), TO_REDACT is what has to catch it.
+    """
+    payload = {
+        "list": [
+            {
+                "lockId": 7252408,
+                "lockAlias": "Front Door",
+                "lockMac": "00:00:00:00:00:00",
+                "lockData": "super-secret-ble-blob",
+            }
+        ]
+    }
+
+    redacted = async_redact_data(payload, TO_REDACT)
+
+    assert redacted["list"][0]["lockData"] == "**REDACTED**"
+    assert redacted["list"][0]["lockAlias"] == "Front Door"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -304,3 +304,11 @@ class TestLockSummary:
 
     def test_not_connectable_without_gateway_or_wifi(self):
         assert self._summary(hasGateway=0, featureValue="0").connectable is False
+
+    def test_lock_data_is_parsed_when_present(self):
+        """lock/list is the only endpoint that returns the BLE credential blob."""
+        assert self._summary(lockData="Ax9dQ0pF").lockData == "Ax9dQ0pF"
+
+    def test_lock_data_is_none_when_absent(self):
+        """Older accounts and trimmed fixtures omit it - that must not be fatal."""
+        assert self._summary().lockData is None


### PR DESCRIPTION
Part of the local BLE transport proposed in #325 (M0). Smallest possible enabling step: no behaviour change, nothing reads the field yet.

## What

`lock/list` already returns `lockData` — the opaque per-lock credential blob TTLock's own SDK uses to talk to a lock directly over BLE (documented in `docs/ttlock-cloud-api/lock/list.md`). `LockSummary` didn't parse it. This adds it as an optional, opaque `str | None` field.

## Why

Carrying `lockData` on the existing developer OAuth2 session is what lets a future local BLE transport work **without a second authentication path** (no mobile-app login). It's the enabling step behind #325 and safe to land on its own.

## Safety

- **No behaviour change** — the field is parsed and otherwise unused.
- `lockData` is already in `const.TO_REDACT`; a new `test_to_redact_covers_lock_data` guards that it stays redacted if/when it ever reaches a diagnostics dump.
- Absent field stays `None` (older accounts / trimmed fixtures don't break).

## Tests

`script/check` clean (lint + `ty` + full suite, 272 passing). New: two `LockSummary` parse tests and the redaction guard; the `lock/list` fixture now carries `lockData` so nothing regresses to assuming it's absent.
