### PR TITLE
ble: add local Bluetooth presence sensor

### DIFF
--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -123,6 +123,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ]
     hass.data[DOMAIN][entry.entry_id][TT_LOCKS] = locks
 
+    for coordinator in locks:
+        entry.async_on_unload(coordinator.async_start_ble_tracking())
+
     gateway_coordinator = GatewaysUpdateCoordinator(hass, entry, client)
     await gateway_coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id][TT_GATEWAYS] = gateway_coordinator

--- a/custom_components/ttlock/ble.py
+++ b/custom_components/ttlock/ble.py
@@ -1,39 +1,7 @@
 """Local Bluetooth presence for TTLock locks.
 
-This is the read-only, passive layer: it answers "can this Home Assistant
-instance hear this lock's radio, how strongly, and via which adapter" by
-watching the advertisements the lock is broadcasting anyway. No connection,
-no protocol, no cost to the lock's battery - nothing here ever writes to the
-lock or even opens a GATT session.
-
-That question is the one a user would otherwise stand up a Bluetooth proxy to
-answer: is the lock in range of the HA host at all, and is the signal good
-enough that a future local transport could work here, or does the door need a
-proxy/gateway. The RSSI it surfaces is the measurement that decides it.
-
-Everything goes through `homeassistant.components.bluetooth` rather than
-bleak directly. That is what makes the radio source interchangeable: a
-Bluetooth adapter on the HA host, an ESPHome Bluetooth proxy, or a
-purpose-built gateway all surface through the same API, so adding one later
-needs no change here.
-
-Bluetooth is an *optional* enhancement - a TTLock account works perfectly
-well over the cloud on a host with no Bluetooth at all. That shapes two
-things:
-
-- manifest.json lists `bluetooth` under `after_dependencies`, not
-  `dependencies`, and every entry point here checks
-  `async_bluetooth_available` first. Calling the bluetooth APIs when the
-  component was never set up raises out of habluetooth's manager singleton.
-- The `homeassistant.components.bluetooth` import is deferred into the
-  functions that need it, the same way webhook.py defers `cloud`. Importing
-  it pulls in the `usb` component and a chain of Linux-only packages
-  (aiousbwatcher -> asyncinotify), which a cloud-only install has no reason
-  to load and which can't be added to this repo's dev dependencies without
-  breaking `uv sync` on macOS. Because `async_bluetooth_available` gates
-  every one of those imports, the component is by then already in
-  sys.modules and the import is a dict lookup, not disk I/O in the event
-  loop.
+Read-only, passive layer that listens for the advertisements the lock is
+broadcasting anyway.
 """
 
 from __future__ import annotations
@@ -58,12 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class BleData:
-    """What the local radio currently knows about one lock.
-
-    The default - every field empty - is the honest "we have never heard
-    this lock" state, which is also what a lock that has gone silent decays
-    back to.
-    """
+    """What we know about the lock via ble, empty means nothing."""
 
     rssi: int | None = None
     last_seen: datetime | None = None
@@ -81,15 +44,10 @@ class BleData:
             return None
         return (now - self.last_seen).total_seconds()
 
-    def as_dict(self, now: datetime) -> dict:
-        """Serialize for diagnostics, dated against `now`.
-
-        The age is included rather than left to be reconstructed from
-        `last_seen` and the download time. An advertisement is only evidence
-        of what the lock was doing when it was *emitted*, so a payload read
-        without its age has already been misread once. A dump has to be a
-        self-dating sample or it is not a sample.
-        """
+    @property
+    def as_dict(self) -> dict:
+        """Serialize for diagnostics, snapshot in time with now being a reference for age."""
+        now = dt_util.utcnow()
         return {
             "rssi": self.rssi,
             "last_seen": self.last_seen,
@@ -139,35 +97,17 @@ def async_track_address(
 ) -> CALLBACK_TYPE:
     """Watch one BLE address, calling `on_change` whenever presence changes.
 
-    Fires once immediately if the stack has already heard the address, so a
-    lock that was advertising before this integration loaded doesn't have to
-    wait for its next advertisement to show up. Fires with an empty
-    `BleData` when the bluetooth component declares the address unavailable,
-    which is what stops a stale RSSI from being reported forever after a
-    lock is taken off the door.
-
-    Matching uses `connectable=False`, which widens rather than narrows: it
-    means "any scanner that can hear it", including passive-only proxies.
-    Whether a *connectable* path exists is reported per-advertisement via
-    `BleData.connectable` instead of being a precondition for seeing the
-    lock at all - for the "do I need a gateway here?" question, a sighting
-    from a passive scanner is still a useful answer.
-
-    Returns an unsubscribe callable; the caller owns its lifetime.
+    Fires on registration if address has been seen. Also fires later with empty
+    payload if the address becomes unavailable.
     """
     from homeassistant.components import bluetooth  # noqa: PLC0415
-
-    # HA canonicalises BLE addresses as upper-case colon-separated MACs, which
-    # is also what lock/list returns - normalise anyway, because the TTLock
-    # cloud is not consistent about case between endpoints and a lower-case
-    # address silently matches nothing.
-    address = address.upper()
 
     @callback
     def _advertisement(
         service_info: BluetoothServiceInfoBleak,
         change: BluetoothChange,
     ) -> None:
+        _LOGGER.debug("Lock %s received BLE advertisement", address)
         on_change(_ble_data(service_info))
 
     @callback

--- a/custom_components/ttlock/ble.py
+++ b/custom_components/ttlock/ble.py
@@ -1,0 +1,198 @@
+"""Local Bluetooth presence for TTLock locks.
+
+This is the read-only, passive layer: it answers "can this Home Assistant
+instance hear this lock's radio, how strongly, and via which adapter" by
+watching the advertisements the lock is broadcasting anyway. No connection,
+no protocol, no cost to the lock's battery - nothing here ever writes to the
+lock or even opens a GATT session.
+
+That question is the one a user would otherwise stand up a Bluetooth proxy to
+answer: is the lock in range of the HA host at all, and is the signal good
+enough that a future local transport could work here, or does the door need a
+proxy/gateway. The RSSI it surfaces is the measurement that decides it.
+
+Everything goes through `homeassistant.components.bluetooth` rather than
+bleak directly. That is what makes the radio source interchangeable: a
+Bluetooth adapter on the HA host, an ESPHome Bluetooth proxy, or a
+purpose-built gateway all surface through the same API, so adding one later
+needs no change here.
+
+Bluetooth is an *optional* enhancement - a TTLock account works perfectly
+well over the cloud on a host with no Bluetooth at all. That shapes two
+things:
+
+- manifest.json lists `bluetooth` under `after_dependencies`, not
+  `dependencies`, and every entry point here checks
+  `async_bluetooth_available` first. Calling the bluetooth APIs when the
+  component was never set up raises out of habluetooth's manager singleton.
+- The `homeassistant.components.bluetooth` import is deferred into the
+  functions that need it, the same way webhook.py defers `cloud`. Importing
+  it pulls in the `usb` component and a chain of Linux-only packages
+  (aiousbwatcher -> asyncinotify), which a cloud-only install has no reason
+  to load and which can't be added to this repo's dev dependencies without
+  breaking `uv sync` on macOS. Because `async_bluetooth_available` gates
+  every one of those imports, the component is by then already in
+  sys.modules and the import is a dict lookup, not disk I/O in the event
+  loop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from homeassistant.components.bluetooth import (
+        BluetoothChange,
+        BluetoothServiceInfoBleak,
+    )
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BleData:
+    """What the local radio currently knows about one lock.
+
+    The default - every field empty - is the honest "we have never heard
+    this lock" state, which is also what a lock that has gone silent decays
+    back to.
+    """
+
+    rssi: int | None = None
+    last_seen: datetime | None = None
+    source: str | None = None
+    connectable: bool = False
+
+    @property
+    def in_range(self) -> bool:
+        """Whether the lock is currently advertising within earshot."""
+        return self.rssi is not None
+
+    def age_seconds(self, now: datetime) -> float | None:
+        """How long since this lock was last heard, or None if never."""
+        if self.last_seen is None:
+            return None
+        return (now - self.last_seen).total_seconds()
+
+    def as_dict(self, now: datetime) -> dict:
+        """Serialize for diagnostics, dated against `now`.
+
+        The age is included rather than left to be reconstructed from
+        `last_seen` and the download time. An advertisement is only evidence
+        of what the lock was doing when it was *emitted*, so a payload read
+        without its age has already been misread once. A dump has to be a
+        self-dating sample or it is not a sample.
+        """
+        return {
+            "rssi": self.rssi,
+            "last_seen": self.last_seen,
+            "age_seconds": self.age_seconds(now),
+            "source": self.source,
+            "connectable": self.connectable,
+        }
+
+
+@callback
+def async_bluetooth_available(hass: HomeAssistant) -> bool:
+    """Whether the bluetooth component is set up and safe to call into.
+
+    `after_dependencies` guarantees bluetooth is set up *before* us if it is
+    going to be set up at all, so checking loaded components once at setup
+    time is sufficient - there is no window where it appears later during
+    our own setup.
+    """
+    return "bluetooth" in hass.config.components
+
+
+def _ble_data(service_info: BluetoothServiceInfoBleak) -> BleData:
+    """Translate one advertisement into our own small view of it.
+
+    `service_info.time` is a coarse monotonic stamp from when the
+    advertisement was received, not wall clock. Converting it against
+    MONOTONIC_TIME() here means a live callback yields ~now while a
+    replayed last-known advertisement yields its true age, using one
+    expression for both.
+    """
+    from homeassistant.components import bluetooth  # noqa: PLC0415
+
+    age = max(0.0, bluetooth.MONOTONIC_TIME() - service_info.time)
+    return BleData(
+        rssi=service_info.rssi,
+        last_seen=dt_util.utcnow() - timedelta(seconds=age),
+        source=service_info.source,
+        connectable=service_info.connectable,
+    )
+
+
+@callback
+def async_track_address(
+    hass: HomeAssistant,
+    address: str,
+    on_change: Callable[[BleData], None],
+) -> CALLBACK_TYPE:
+    """Watch one BLE address, calling `on_change` whenever presence changes.
+
+    Fires once immediately if the stack has already heard the address, so a
+    lock that was advertising before this integration loaded doesn't have to
+    wait for its next advertisement to show up. Fires with an empty
+    `BleData` when the bluetooth component declares the address unavailable,
+    which is what stops a stale RSSI from being reported forever after a
+    lock is taken off the door.
+
+    Matching uses `connectable=False`, which widens rather than narrows: it
+    means "any scanner that can hear it", including passive-only proxies.
+    Whether a *connectable* path exists is reported per-advertisement via
+    `BleData.connectable` instead of being a precondition for seeing the
+    lock at all - for the "do I need a gateway here?" question, a sighting
+    from a passive scanner is still a useful answer.
+
+    Returns an unsubscribe callable; the caller owns its lifetime.
+    """
+    from homeassistant.components import bluetooth  # noqa: PLC0415
+
+    # HA canonicalises BLE addresses as upper-case colon-separated MACs, which
+    # is also what lock/list returns - normalise anyway, because the TTLock
+    # cloud is not consistent about case between endpoints and a lower-case
+    # address silently matches nothing.
+    address = address.upper()
+
+    @callback
+    def _advertisement(
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        on_change(_ble_data(service_info))
+
+    @callback
+    def _unavailable(service_info: BluetoothServiceInfoBleak) -> None:
+        _LOGGER.debug("Lock %s is no longer in Bluetooth range", address)
+        on_change(BleData())
+
+    unsubscribes = [
+        bluetooth.async_register_callback(
+            hass,
+            _advertisement,
+            {"address": address, "connectable": False},
+            bluetooth.BluetoothScanningMode.ACTIVE,
+        ),
+        bluetooth.async_track_unavailable(
+            hass, _unavailable, address, connectable=False
+        ),
+    ]
+
+    if last_seen := bluetooth.async_last_service_info(hass, address, connectable=False):
+        on_change(_ble_data(last_seen))
+
+    @callback
+    def _unsubscribe() -> None:
+        for unsubscribe in unsubscribes:
+            unsubscribe()
+
+    return _unsubscribe

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -21,7 +21,7 @@ import logging
 from typing import TypeGuard
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
@@ -29,6 +29,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from .api import TTLockApi
+from .ble import BleData, async_bluetooth_available, async_track_address
 from .capture import LockTrafficCapture
 from .const import (
     CONF_POLL_INTERVAL,
@@ -234,6 +235,12 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         self._capture = capture
         self._store = store
 
+        # Latest passive Bluetooth presence for this lock: RSSI, when it was
+        # last heard and via which adapter. Empty until async_start_ble_tracking
+        # hears the first advertisement (or immediately, if the stack already
+        # has one). Read-only - nothing here connects to the lock.
+        self.ble: BleData = BleData()
+
         # Whether we've already made this restart's one-shot door-sensor
         # recheck (see _check_for_sensor) - deliberately in-memory, not
         # persisted, so it naturally resets to False on every restart.
@@ -269,6 +276,29 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         )
 
         async_dispatcher_connect(self.hass, SIGNAL_NEW_DATA, self._process_webhook_data)
+
+    @callback
+    def async_start_ble_tracking(self) -> CALLBACK_TYPE:
+        """Begin watching this lock's Bluetooth presence.
+
+        Returns an unsubscribe callable for the caller to register with
+        `entry.async_on_unload`. When the bluetooth component isn't set up
+        there is nothing to watch, so this is a no-op that returns a no-op -
+        the lock keeps working over the cloud exactly as before.
+        """
+        if not async_bluetooth_available(self.hass):
+            return lambda: None
+        return async_track_address(self.hass, self.data.mac, self._async_ble_updated)
+
+    @callback
+    def _async_ble_updated(self, ble: BleData) -> None:
+        """Record new presence and let entities re-read it.
+
+        This is passive - a presence change never triggers a cloud poll or a
+        connection, it only refreshes what the RSSI sensor reports.
+        """
+        self.ble = ble
+        self.async_update_listeners()
 
     async def _async_update_data(self) -> LockState:
         if not self.connectable:

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -235,10 +235,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         self._capture = capture
         self._store = store
 
-        # Latest passive Bluetooth presence for this lock: RSSI, when it was
-        # last heard and via which adapter. Empty until async_start_ble_tracking
-        # hears the first advertisement (or immediately, if the stack already
-        # has one). Read-only - nothing here connects to the lock.
+        # Latest passive Bluetooth presence for this lock.
+        # Empty until async_start_ble_tracking hears the first
+        # advertisement (or immediately, if the stack already has one)
         self.ble: BleData = BleData()
 
         # Whether we've already made this restart's one-shot door-sensor

--- a/custom_components/ttlock/manifest.json
+++ b/custom_components/ttlock/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ttlock",
   "name": "TTLock",
-  "after_dependencies": ["cloud"],
+  "after_dependencies": ["bluetooth", "cloud"],
   "codeowners": ["@jbergler"],
   "config_flow": true,
   "dependencies": [

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -60,13 +60,28 @@ class SensorState(Enum):
     unknown = None
 
 
-class Lock(BaseModel):
+class LockMacModel(BaseModel):
+    """Base for API models carrying a lock MAC.
+
+    Normalises it at parse time so internal state is consistent no matter
+    which endpoint (lock/list, lock/detail) it came from - HA matches BLE on
+    upper-case MACs and the cloud isn't consistent about case.
+    """
+
+    mac: str = Field(..., alias="lockMac")
+
+    @field_validator("mac")
+    @classmethod
+    def _normalise_mac(cls, mac: str) -> str:
+        return mac.upper()
+
+
+class Lock(LockMacModel):
     """Lock details."""
 
     id: int = Field(..., alias="lockId")
     type: str = Field(..., alias="lockName")
     name: str = Field("Lock", alias="lockAlias")
-    mac: str = Field(..., alias="lockMac")
     battery_level: int | None = Field(None, alias="electricQuantity")
     featureValue: str | None = None
     timezoneRawOffset: int = 0
@@ -87,12 +102,11 @@ class Lock(BaseModel):
     noKeyPwd: str = Field(alias="adminPwd")
 
 
-class LockSummary(BaseModel):
+class LockSummary(LockMacModel):
     """Cheap per-lock summary from lock/list, enough to build a device/entities without a detail fetch."""
 
     id: int = Field(..., alias="lockId")
     name: str = Field("Lock", alias="lockAlias")
-    mac: str = Field(..., alias="lockMac")
     featureValue: str | None = None
     hasGateway: int = 0
 

--- a/custom_components/ttlock/sensor.py
+++ b/custom_components/ttlock/sensor.py
@@ -37,9 +37,6 @@ async def async_setup_entry(
 
     coordinators = list(lock_coordinators(hass, entry))
 
-    # Only add the local-radio RSSI sensor when HA actually has Bluetooth set
-    # up; on a cloud-only host it would sit permanently unavailable and mean
-    # nothing (see ble.async_bluetooth_available).
     with_bluetooth = async_bluetooth_available(hass)
 
     async_add_entities(

--- a/custom_components/ttlock/sensor.py
+++ b/custom_components/ttlock/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
+from .ble import async_bluetooth_available
 from .coordinator import async_add_when_sensor_present, lock_coordinators
 from .entity import BaseLockEntity
 
@@ -36,6 +37,11 @@ async def async_setup_entry(
 
     coordinators = list(lock_coordinators(hass, entry))
 
+    # Only add the local-radio RSSI sensor when HA actually has Bluetooth set
+    # up; on a cloud-only host it would sit permanently unavailable and mean
+    # nothing (see ble.async_bluetooth_available).
+    with_bluetooth = async_bluetooth_available(hass)
+
     async_add_entities(
         [
             entity
@@ -45,6 +51,7 @@ async def async_setup_entry(
                 LockOperator(coordinator),
                 LockTrigger(coordinator),
                 *([LockGateway(coordinator)] if coordinator.has_gateway else []),
+                *([LockBleSignal(coordinator)] if with_bluetooth else []),
             )
         ]
     )
@@ -164,4 +171,38 @@ class LockGateway(BaseLockEntity, SensorEntity):
                 {"name": gateway.name, "mac": gateway.mac, "rssi": gateway.rssi}
                 for gateway in others
             ],
+        }
+
+
+class LockBleSignal(BaseLockEntity, SensorEntity):
+    """RSSI of the lock as heard directly by HA's own Bluetooth stack.
+
+    Distinct from LockGateway, which reports how well the *TTLock gateway*
+    hears the lock - this reports how well *we* hear it, with no TTLock
+    hardware in between. Diagnostic and disabled by default: it exists to
+    answer "is this lock within local radio range, and would a Bluetooth
+    proxy help?", which is a placement question, not a dashboard one.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def _update_from_coordinator(self) -> None:
+        """Fetch state from the device."""
+        self._attr_name = f"{self.coordinator.data.name} Bluetooth Signal"
+        self._attr_native_value = self.coordinator.ble.rssi
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Which adapter/proxy heard the lock, when, and whether it can connect."""
+        ble = self.coordinator.ble
+        if not ble.in_range:
+            return None
+        return {
+            "source": ble.source,
+            "connectable": ble.connectable,
+            "last_seen": ble.last_seen.isoformat() if ble.last_seen else None,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,23 @@
 """Global fixtures for ttlock integration."""
 
+from collections.abc import Callable
 import sys
 from time import time
 import types
-from typing import NamedTuple
+from typing import Any, NamedTuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientSession
+from bleak.backends.device import BLEDevice
+
+# The real objects HA's bluetooth component re-exports, imported from the
+# packages it gets them from because the component itself can't be loaded
+# here (see mock_bluetooth) - so ble.py still measures advertisement age
+# against the same clock and matches the same scanning-mode enum it would in
+# production.
+from bluetooth_data_tools import monotonic_time_coarse
+from habluetooth import BluetoothScanningMode
+from home_assistant_bluetooth import BluetoothServiceInfoBleak
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -37,8 +48,11 @@ from .const import (
     LOCK_DETAILS_WITH_SENSOR,
     LOCK_STATE_LOCKED,
     LOCK_STATE_UNLOCKED,
+    MOCK_LOCK_MAC,
+    MOCK_LOCK_NAME,
     PASSAGE_MODE_6_TO_6_7_DAYS,
     SENSOR_DETAILS,
+    TTLOCK_SERVICE_UUID,
 )
 
 pytest_plugins = "pytest_homeassistant_custom_component"
@@ -317,3 +331,93 @@ def mock_cloud(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     monkeypatch.setattr(ha_components, "cloud", stub, raising=False)
 
     return stub
+
+
+class BluetoothRecorder:
+    """What ble.py asked HA's bluetooth component to do."""
+
+    def __init__(self) -> None:
+        self.matcher: dict | None = None
+        self.mode: BluetoothScanningMode | None = None
+        self.advertisement: Callable | None = None
+        self.unavailable: Callable | None = None
+        self.unavailable_address: str | None = None
+        self.unavailable_connectable: bool | None = None
+        self.seed: BluetoothServiceInfoBleak | None = None
+        self.seed_address: str | None = None
+        self.unsubscribed: list[str] = []
+
+
+@pytest.fixture
+def ble_advertisement():
+    """Factory: one plausible advertisement from a TTLock lock."""
+
+    def _advertisement(**overrides) -> BluetoothServiceInfoBleak:
+        address = overrides.pop("address", MOCK_LOCK_MAC)
+        kwargs: dict[str, Any] = {
+            "name": MOCK_LOCK_NAME,
+            "address": address,
+            "rssi": -62,
+            "manufacturer_data": {},
+            "service_data": {},
+            "service_uuids": [TTLOCK_SERVICE_UUID],
+            "source": "local",
+            "device": BLEDevice(address, MOCK_LOCK_NAME, {}),
+            "advertisement": None,
+            "connectable": True,
+            "time": monotonic_time_coarse(),
+            "tx_power": -127,
+        }
+        kwargs.update(overrides)
+        return BluetoothServiceInfoBleak(**kwargs)
+
+    return _advertisement
+
+
+@pytest.fixture
+def mock_bluetooth(
+    monkeypatch: pytest.MonkeyPatch, hass: HomeAssistant
+) -> BluetoothRecorder:
+    """Stand in for a set-up bluetooth component, recording every call.
+
+    homeassistant.components.bluetooth is unimportable in this test
+    environment - its import chain reaches the usb component and then
+    aiousbwatcher/asyncinotify, which are Linux-only - so it gets the same
+    treatment as mock_cloud above, and for the same reason ble.py defers the
+    import rather than taking it at module scope.
+
+    Marking "bluetooth" as a loaded component is part of the stub: that is
+    exactly what ble.async_bluetooth_available checks before it will import
+    or call anything here, so requesting this fixture is what turns local
+    Bluetooth on for a test.
+    """
+    recorder = BluetoothRecorder()
+
+    def register_callback(hass, callback, matcher, mode):
+        recorder.advertisement = callback
+        recorder.matcher = matcher
+        recorder.mode = mode
+        return lambda: recorder.unsubscribed.append("advertisement")
+
+    def track_unavailable(hass, callback, address, connectable):
+        recorder.unavailable = callback
+        recorder.unavailable_address = address
+        recorder.unavailable_connectable = connectable
+        return lambda: recorder.unsubscribed.append("unavailable")
+
+    def last_service_info(hass, address, connectable=True):
+        recorder.seed_address = address
+        return recorder.seed
+
+    stub = types.ModuleType("homeassistant.components.bluetooth")
+    stub.async_register_callback = register_callback  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.async_track_unavailable = track_unavailable  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.async_last_service_info = last_service_info  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.BluetoothScanningMode = BluetoothScanningMode  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.MONOTONIC_TIME = monotonic_time_coarse  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+
+    monkeypatch.setitem(sys.modules, "homeassistant.components.bluetooth", stub)
+    monkeypatch.setattr(ha_components, "bluetooth", stub, raising=False)
+    hass.config.components.add("bluetooth")
+
+    return recorder

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,5 +1,15 @@
 """Dummy data for tests."""
 
+# The lock the Bluetooth-presence tests advertise as. Matches BASIC_LOCK_DETAILS
+# below so a single lock is consistent across cloud and BLE fixtures.
+MOCK_LOCK_MAC = "16:72:4C:CC:01:C4"
+MOCK_LOCK_NAME = "S31_c401cc"
+
+# TTLock's GATT service, advertised by every lock. Used only to give the mock
+# advertisement a plausible service uuid; ble.py's presence layer doesn't read
+# it.
+TTLOCK_SERVICE_UUID = "00001910-0000-1000-8000-00805f9b34fb"
+
 BASIC_LOCK_DETAILS = {
     "date": 1669690212000,
     "lockAlias": "Front Door",

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -1,0 +1,236 @@
+"""Tests for local Bluetooth presence tracking.
+
+conftest's mock_bluetooth stands in for HA's bluetooth component - see its
+docstring for why the real one can't be loaded here. Stubbing at exactly the
+seam ble.py uses (three functions and a matcher) is what lets these assert
+the things that are easy to get silently wrong: that the address is
+normalised, that a lock heard before we loaded is picked up without waiting
+for its next advertisement, that going out of range clears the reading
+rather than freezing it, and that unsubscribing releases both registrations.
+"""
+
+from datetime import timedelta
+
+from habluetooth import BluetoothScanningMode
+import pytest
+
+from custom_components.ttlock.ble import (
+    BleData,
+    async_bluetooth_available,
+    async_track_address,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .const import MOCK_LOCK_MAC as LOCK_MAC
+
+# BluetoothChange has exactly one member and ble.py ignores the argument
+# entirely; this stands in for it.
+ADVERTISEMENT = "advertisement"
+
+
+class TestBleData:
+    def test_never_heard_is_not_in_range(self):
+        assert BleData().in_range is False
+
+    def test_an_rssi_means_in_range(self):
+        assert BleData(rssi=-62).in_range is True
+
+    def test_zero_rssi_still_means_in_range(self):
+        """0 dBm is implausibly strong but falsy - it must not read as absent."""
+        assert BleData(rssi=0).in_range is True
+
+    def test_a_dump_dates_the_advertisement_it_reports(self):
+        """The payload and its age have to travel together.
+
+        Read apart they have already produced a wrong answer: a payload
+        emitted 222s before the operation it was taken to describe. Whoever
+        reads a dump gets the age without having to know that.
+        """
+        now = dt_util.utcnow()
+        data = BleData(
+            rssi=-80,
+            last_seen=now - timedelta(seconds=222.6),
+            source="local",
+            connectable=True,
+        )
+
+        dumped = data.as_dict(now)
+
+        assert dumped["rssi"] == -80
+        assert dumped["source"] == "local"
+        assert dumped["connectable"] is True
+        assert dumped["age_seconds"] == pytest.approx(222.6)
+
+    def test_a_lock_never_heard_reports_no_age(self):
+        """None, not 0 - which would read as an advertisement received now."""
+        assert BleData().as_dict(dt_util.utcnow())["age_seconds"] is None
+
+
+class TestAsyncBluetoothAvailable:
+    async def test_false_when_component_is_not_set_up(self, hass: HomeAssistant):
+        assert async_bluetooth_available(hass) is False
+
+    async def test_true_once_component_is_set_up(self, hass: HomeAssistant):
+        hass.config.components.add("bluetooth")
+        assert async_bluetooth_available(hass) is True
+
+
+class TestAsyncTrackAddress:
+    @pytest.fixture
+    def seen(self) -> list[BleData]:
+        return []
+
+    @pytest.fixture
+    def track(self, hass: HomeAssistant, mock_bluetooth, seen):
+        """Track LOCK_MAC, appending every reported change to `seen`."""
+
+        def _track(address: str = LOCK_MAC):
+            return async_track_address(hass, address, seen.append)
+
+        return _track
+
+    def test_matches_the_lock_by_address(self, track, mock_bluetooth):
+        track()
+
+        assert mock_bluetooth.matcher == {"address": LOCK_MAC, "connectable": False}
+        assert mock_bluetooth.mode is BluetoothScanningMode.ACTIVE
+
+    def test_lower_case_addresses_are_normalised(self, track, mock_bluetooth):
+        """The cloud isn't consistent about case; a lower-case matcher matches nothing."""
+        track(LOCK_MAC.lower())
+
+        assert mock_bluetooth.matcher == {"address": LOCK_MAC, "connectable": False}
+        assert mock_bluetooth.unavailable_address == LOCK_MAC
+        assert mock_bluetooth.seed_address == LOCK_MAC
+
+    def test_watches_non_connectable_scanners_too(self, track, mock_bluetooth):
+        """A passive-only sighting still answers "is the lock in range?"."""
+        track()
+
+        assert mock_bluetooth.unavailable_connectable is False
+
+    def test_nothing_reported_when_lock_was_never_heard(self, track, seen):
+        track()
+
+        assert seen == []
+
+    def test_seeds_from_the_last_known_advertisement(
+        self, track, mock_bluetooth, ble_advertisement, seen
+    ):
+        """A lock advertising before we loaded shouldn't wait for the next packet."""
+        mock_bluetooth.seed = ble_advertisement(rssi=-55, source="AA:BB:CC:DD:EE:FF")
+
+        track()
+
+        assert len(seen) == 1
+        assert seen[0].rssi == -55
+        assert seen[0].source == "AA:BB:CC:DD:EE:FF"
+        assert seen[0].connectable is True
+        assert seen[0].in_range is True
+
+    def test_seeded_last_seen_reflects_the_advertisement_age(
+        self, track, mock_bluetooth, ble_advertisement, seen
+    ):
+        """The seed can be minutes old - it must not be stamped as "now"."""
+        stale = ble_advertisement()
+        mock_bluetooth.seed = ble_advertisement(time=stale.time - 30)
+        before = dt_util.utcnow()
+
+        track()
+
+        last_seen = seen[0].last_seen
+        assert last_seen is not None
+        assert 29 <= (before - last_seen).total_seconds() <= 31
+
+    def test_advertisements_are_reported(
+        self, track, mock_bluetooth, ble_advertisement, seen
+    ):
+        track()
+        assert mock_bluetooth.advertisement is not None
+
+        mock_bluetooth.advertisement(ble_advertisement(rssi=-71), ADVERTISEMENT)
+
+        assert seen[-1].rssi == -71
+
+    def test_going_out_of_range_clears_the_reading(
+        self, track, mock_bluetooth, ble_advertisement, seen
+    ):
+        """A frozen RSSI would claim a lock is in range long after it isn't."""
+        track()
+        assert mock_bluetooth.advertisement is not None
+        assert mock_bluetooth.unavailable is not None
+
+        mock_bluetooth.advertisement(ble_advertisement(), ADVERTISEMENT)
+        mock_bluetooth.unavailable(ble_advertisement())
+
+        assert seen[-1] == BleData()
+        assert seen[-1].in_range is False
+
+    def test_unsubscribing_releases_both_registrations(self, track, mock_bluetooth):
+        unsubscribe = track()
+
+        unsubscribe()
+
+        assert sorted(mock_bluetooth.unsubscribed) == ["advertisement", "unavailable"]
+
+
+class TestCoordinatorBleTracking:
+    """The coordinator's half - starting tracking, and coping without it."""
+
+    async def test_starts_with_no_reading(self, coordinator):
+        assert coordinator.ble == BleData()
+
+    async def test_no_bluetooth_yields_a_working_no_op_unsubscribe(self, coordinator):
+        """A cloud-only host must still set up - and tear down - cleanly."""
+        unsubscribe = coordinator.async_start_ble_tracking()
+
+        unsubscribe()
+
+        assert coordinator.ble == BleData()
+
+    async def test_tracks_the_lock_when_bluetooth_is_set_up(
+        self, coordinator, mock_bluetooth, ble_advertisement
+    ):
+        mock_bluetooth.seed = ble_advertisement(address=coordinator.data.mac, rssi=-48)
+
+        coordinator.async_start_ble_tracking()
+
+        assert mock_bluetooth.matcher == {
+            "address": coordinator.data.mac,
+            "connectable": False,
+        }
+        assert coordinator.ble.rssi == -48
+
+    async def test_advertisements_reach_entity_listeners(
+        self, coordinator, mock_bluetooth, ble_advertisement
+    ):
+        """Entities only redraw if the coordinator notifies them."""
+        coordinator.async_start_ble_tracking()
+        assert mock_bluetooth.advertisement is not None
+
+        seen: list[int | None] = []
+        remove = coordinator.async_add_listener(
+            lambda: seen.append(coordinator.ble.rssi)
+        )
+
+        mock_bluetooth.advertisement(
+            ble_advertisement(address=coordinator.data.mac, rssi=-66), ADVERTISEMENT
+        )
+        remove()
+
+        assert seen == [-66]
+
+    async def test_advertisements_leave_lock_state_alone(
+        self, coordinator, mock_bluetooth, ble_advertisement
+    ):
+        """Advertisements say nothing about the lock, and must not stand in for a poll."""
+        coordinator.async_start_ble_tracking()
+        assert mock_bluetooth.advertisement is not None
+        before = coordinator.data
+
+        mock_bluetooth.advertisement(
+            ble_advertisement(address=coordinator.data.mac), ADVERTISEMENT
+        )
+
+        assert coordinator.data is before

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -3,10 +3,10 @@
 conftest's mock_bluetooth stands in for HA's bluetooth component - see its
 docstring for why the real one can't be loaded here. Stubbing at exactly the
 seam ble.py uses (three functions and a matcher) is what lets these assert
-the things that are easy to get silently wrong: that the address is
-normalised, that a lock heard before we loaded is picked up without waiting
-for its next advertisement, that going out of range clears the reading
-rather than freezing it, and that unsubscribing releases both registrations.
+the things that are easy to get silently wrong: that a lock heard before we
+loaded is picked up without waiting for its next advertisement, that going
+out of range clears the reading rather than freezing it, and that
+unsubscribing releases both registrations.
 """
 
 from datetime import timedelta
@@ -47,24 +47,23 @@ class TestBleData:
         emitted 222s before the operation it was taken to describe. Whoever
         reads a dump gets the age without having to know that.
         """
-        now = dt_util.utcnow()
         data = BleData(
             rssi=-80,
-            last_seen=now - timedelta(seconds=222.6),
+            last_seen=dt_util.utcnow() - timedelta(seconds=222.6),
             source="local",
             connectable=True,
         )
 
-        dumped = data.as_dict(now)
+        dumped = data.as_dict
 
         assert dumped["rssi"] == -80
         assert dumped["source"] == "local"
         assert dumped["connectable"] is True
-        assert dumped["age_seconds"] == pytest.approx(222.6)
+        assert dumped["age_seconds"] == pytest.approx(222.6, abs=1)
 
     def test_a_lock_never_heard_reports_no_age(self):
         """None, not 0 - which would read as an advertisement received now."""
-        assert BleData().as_dict(dt_util.utcnow())["age_seconds"] is None
+        assert BleData().as_dict["age_seconds"] is None
 
 
 class TestAsyncBluetoothAvailable:
@@ -95,14 +94,6 @@ class TestAsyncTrackAddress:
 
         assert mock_bluetooth.matcher == {"address": LOCK_MAC, "connectable": False}
         assert mock_bluetooth.mode is BluetoothScanningMode.ACTIVE
-
-    def test_lower_case_addresses_are_normalised(self, track, mock_bluetooth):
-        """The cloud isn't consistent about case; a lower-case matcher matches nothing."""
-        track(LOCK_MAC.lower())
-
-        assert mock_bluetooth.matcher == {"address": LOCK_MAC, "connectable": False}
-        assert mock_bluetooth.unavailable_address == LOCK_MAC
-        assert mock_bluetooth.seed_address == LOCK_MAC
 
     def test_watches_non_connectable_scanners_too(self, track, mock_bluetooth):
         """A passive-only sighting still answers "is the lock in range?"."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -304,3 +304,7 @@ class TestLockSummary:
 
     def test_not_connectable_without_gateway_or_wifi(self):
         assert self._summary(hasGateway=0, featureValue="0").connectable is False
+
+    def test_mac_is_upper_cased(self):
+        """HA matches BLE on upper-case MACs; the cloud isn't consistent about case."""
+        assert self._summary(lockMac="16:72:4c:cc:01:c4").mac == "16:72:4C:CC:01:C4"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -308,7 +308,7 @@ class TestLockSummary:
     def test_mac_is_upper_cased(self):
         """HA matches BLE on upper-case MACs; the cloud isn't consistent about case."""
         assert self._summary(lockMac="16:72:4c:cc:01:c4").mac == "16:72:4C:CC:01:C4"
-        
+
     def test_lock_data_is_parsed_when_present(self):
         """lock/list is the only endpoint that returns the BLE credential blob."""
         assert self._summary(lockData="Ax9dQ0pF").lockData == "Ax9dQ0pF"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,6 +11,8 @@ from custom_components.ttlock.const import DOMAIN
 from custom_components.ttlock.models import GatewayLink, LockSummary
 from homeassistant.helpers import entity_registry as er
 
+from .const import MOCK_LOCK_MAC
+
 
 async def test_sensor_battery_entity_appears_once_presence_confirmed(
     hass, component_setup, mock_api_responses
@@ -135,3 +137,61 @@ async def test_gateway_signal_entity_not_created_for_wifi_only_lock(
         "sensor", DOMAIN, f"{coordinator.unique_id}-lockgateway"
     )
     assert entity_id is None
+
+
+async def test_bluetooth_signal_entity_not_created_without_bluetooth(
+    hass, component_setup, mock_api_responses
+):
+    """A cloud-only host would only ever get an entity stuck on "unknown"."""
+    mock_api_responses("default")
+    coordinator = await component_setup()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{coordinator.unique_id}-lockblesignal"
+    )
+    assert entity_id is None
+
+
+async def test_bluetooth_signal_entity_disabled_by_default(
+    hass, component_setup, mock_api_responses, mock_bluetooth
+):
+    mock_api_responses("default")
+    coordinator = await component_setup()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{coordinator.unique_id}-lockblesignal"
+    )
+    assert entity_id is not None
+    entry = registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get(entity_id) is None
+
+
+async def test_bluetooth_signal_entity_reports_locally_heard_rssi(
+    hass, component_setup, mock_api_responses, mock_bluetooth, ble_advertisement
+):
+    """The whole point of M1: how well does *this host* hear the lock?"""
+    mock_api_responses("default")
+    mock_bluetooth.seed = ble_advertisement(
+        address=MOCK_LOCK_MAC, rssi=-58, source="00:11:22:33:44:55"
+    )
+    coordinator = await component_setup()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{coordinator.unique_id}-lockblesignal"
+    )
+    assert entity_id is not None
+    registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(coordinator.config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "-58"
+    assert state.attributes["source"] == "00:11:22:33:44:55"
+    assert state.attributes["connectable"] is True
+    assert state.attributes["last_seen"] is not None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,7 @@ confirms presence, not decided up front.
 
 from custom_components.ttlock.const import DOMAIN
 from custom_components.ttlock.models import GatewayLink, LockSummary
+from custom_components.ttlock.sensor import LockBleSignal
 from homeassistant.helpers import entity_registry as er
 
 from .const import MOCK_LOCK_MAC
@@ -195,3 +196,8 @@ async def test_bluetooth_signal_entity_reports_locally_heard_rssi(
     assert state.attributes["source"] == "00:11:22:33:44:55"
     assert state.attributes["connectable"] is True
     assert state.attributes["last_seen"] is not None
+
+
+async def test_bluetooth_signal_entity_has_no_attributes_when_never_heard(coordinator):
+    """A lock we've never heard exposes no source/last_seen to report."""
+    assert LockBleSignal(coordinator).extra_state_attributes is None


### PR DESCRIPTION
Follows the plan in discussion #325. This is **M1**, independent of the M0 `lockData` PR (#326) — it touches different files and can land in either order.

## What this adds

A diagnostic **signal-strength sensor** per lock, reporting how well *Home Assistant's own Bluetooth radio* hears the lock — via the host adapter or any ESPHome Bluetooth proxy, through `homeassistant.components.bluetooth`, with **no TTLock gateway in the path**.

It's passive and read-only: it watches the advertisements a lock already broadcasts and never opens a connection or writes anything, so it costs the lock nothing. It answers the placement question a user would otherwise stand up a proxy to measure — *is this lock in local radio range, and is the signal good enough to build on* — which also informs the #268 / #244 class of "detected, no gateway" locks.

## Bluetooth stays optional

- `manifest.json` lists `bluetooth` under **`after_dependencies`**, not `dependencies`.
- Every entry point checks `async_bluetooth_available` first, and the `homeassistant.components.bluetooth` import is deferred into the functions that need it (same pattern `webhook.py` uses for `cloud`).
- On a cloud-only host nothing changes and the RSSI sensor simply isn't created.

The sensor is `EntityCategory.DIAGNOSTIC` and **registry-disabled by default** — placement troubleshooting, not a dashboard entity.

## Files

- **`ble.py`** (new) — presence layer only: `BleData`, `async_bluetooth_available`, `async_track_address`. No GATT, no protocol.
- **`coordinator.py`** — `async_start_ble_tracking` / `_async_ble_updated`; a presence change refreshes the sensor and **never** triggers a cloud poll.
- **`__init__.py`** — starts tracking per lock, unsubscribed via `entry.async_on_unload`.
- **`sensor.py`** — `LockBleSignal`, added only when Bluetooth is set up.
- **`manifest.json`** — `bluetooth` added to `after_dependencies`.

## Tests

24 new tests (`tests/test_ble.py`, plus three in `tests/test_sensor.py`). `mock_bluetooth` / `ble_advertisement` fixtures stand in for the bluetooth component (unimportable in this test env — Linux-only usb chain), stubbed at exactly the seam `ble.py` uses. `script/check` clean — **293 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)