### PR TITLE
ble: add pure BLE wire protocol core

### DIFF
--- a/custom_components/ttlock/ble_protocol.py
+++ b/custom_components/ttlock/ble_protocol.py
@@ -1,0 +1,629 @@
+"""Pure TTLock BLE wire protocol - framing, checksum, and encryption.
+
+Free of I/O by design: it turns Python values into bytes and back, with no
+bleak, Home Assistant, coroutines or clock. That is what lets it be tested
+without a lock present, and reused unchanged if the radio later moves from the
+HA host's own adapter to a proxy or gateway. `ble.py` owns the GATT session
+and calls in here.
+
+Provenance: not ported from any implementation. The public references -
+`kind3r/ttlock-sdk-js` (GPL-3.0), `Fusseldieb/ttlock-reverse-engineering` (no
+licence) and `roquerodrigo/ha-ttlock-ble` (MIT) - were read as documentation
+of the protocol. Field offsets, opcodes, the CRC variant and the cipher mode
+are interface facts and carry no copyright; the code here is written from
+those facts, so this MIT integration is not bound by the GPL reference.
+
+Secrets: nothing here logs. The AES key comes from `lock/detail`'s
+`aesKeyStr`, which `const.py` already redacts, so a debug line carrying a key,
+plaintext or decoded frame would leak it into a diagnostics upload. This
+module therefore has no logger, and callers must keep it that way.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from dataclasses import dataclass
+from enum import IntEnum
+
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# `cryptography` is deliberately absent from manifest.json's requirements:
+# Home Assistant core depends on it and pins a version, so declaring it here
+# could only conflict with that pin.
+
+MAGIC = b"\x7f\x5a"
+"""Start-of-frame marker. Also what the reassembler resynchronises on."""
+
+TERMINATOR = b"\x0d\x0a"
+"""CR+LF, the last two bytes of every frame."""
+
+HEADER_LENGTH = 12
+TRAILER_LENGTH = 3  # CRC-8 + CR + LF
+MAX_DATA_LENGTH = 0xFF  # the length field is one byte
+MAX_FRAME_LENGTH = HEADER_LENGTH + MAX_DATA_LENGTH + TRAILER_LENGTH
+
+AES_KEY_LENGTH = 16
+_AES_BLOCK_BITS = 128
+
+SERVICE_UUID = "00001910-0000-1000-8000-00805f9b34fb"
+"""TTLock's proprietary GATT service - the one carrying command traffic."""
+
+WRITE_UUID = "0000fff2-0000-1000-8000-00805f9b34fb"
+"""Write-without-response characteristic. Commands go out here."""
+
+NOTIFY_UUID = "0000fff4-0000-1000-8000-00805f9b34fb"
+"""Notify characteristic. Responses and unsolicited events arrive here."""
+
+BATTERY_UUID = "00002a19-0000-1000-8000-00805f9b34fb"
+"""Standard Battery Level characteristic - a one-byte read needing no key,
+session or framing."""
+
+
+class Command(IntEnum):
+    """The opcodes this integration needs, from the much longer full set.
+
+    Deliberately partial - an opcode is added only once something sends or
+    handles it. `Frame.command` is a plain int, so an unrecognised opcode is
+    decoded and passed on rather than raising; these members compare equal to
+    the matching int, so callers can still match on them.
+    """
+
+    SEARCH_DEVICE_FEATURE = 1
+    """Ask which features the lock supports. Cheap, unauthenticated probe."""
+
+    QUERY_LOCK_STATUS = 20
+    """Read locked/unlocked state - the local equivalent of a cloud poll."""
+
+    RESPONSE = 84
+    """Generic acknowledgement wrapper the lock replies with."""
+
+
+class ProtocolError(Exception):
+    """Base class for every failure to speak or understand the wire format."""
+
+
+class FrameError(ProtocolError):
+    """A byte sequence is not a well-formed frame."""
+
+
+class ChecksumError(FrameError):
+    """A frame's CRC-8 does not match its contents."""
+
+
+class DecryptError(ProtocolError):
+    """A frame's payload could not be decrypted with the key we hold."""
+
+
+class UnsupportedProtocol(ProtocolError):
+    """The lock is speaking a variant of the protocol we do not implement."""
+
+
+def crc8_maxim(data: bytes) -> int:
+    """Return the CRC-8/MAXIM checksum of `data`.
+
+    Polynomial 0x31, reflected in and out, zero init, zero xor-out. The
+    reflected form is implemented directly (shifting right against 0x8C).
+    """
+    crc = 0
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0x8C if crc & 1 else crc >> 1
+    return crc
+
+
+def parse_aes_key(value: str) -> bytes:
+    """Decode `lock/detail`'s `aesKeyStr` into the 16 raw key bytes.
+
+    The cloud does not document the field's encoding, and the public
+    reverse-engineering work disagrees: hex, separator-delimited hex, base64
+    and comma-separated signed Java bytes all appear. Each is tried and
+    accepted only if it yields exactly 16 bytes, rather than picking one and
+    producing silent garbage when wrong.
+
+    Comma-delimited hex and signed bytes are not mutually exclusive
+    ("12,34,..." is a valid reading of both, giving different keys), so the
+    order is structural: the strict delimited-hex reading claims only 16
+    two-hex-digit tokens - the shape a real lock sends - and anything a signed
+    list does that hex cannot (a minus sign, a one- or three-digit token)
+    falls through to the signed reading.
+
+    Raises:
+        ValueError: if the value matches no known encoding.
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError("aesKeyStr is empty")
+
+    for decode in (
+        _key_from_delimited_hex,
+        _key_from_signed_bytes,
+        _key_from_hex,
+        _key_from_base64,
+    ):
+        if (key := decode(value)) is not None:
+            return key
+
+    raise ValueError(
+        f"aesKeyStr is a {len(value)}-character string in an unrecognised encoding"
+    )
+
+
+# Separators seen between hex byte pairs. Space is absent deliberately:
+# bytes.fromhex already skips ASCII whitespace itself.
+_HEX_SEPARATORS = ":-,."
+
+
+def _key_from_delimited_hex(value: str) -> bytes | None:
+    """Decode "0f,1e,2d,..." - the form a real KT170 returns.
+
+    Strict where `_key_from_hex` is forgiving: insisting on 16 tokens of
+    exactly two hex digits is what lets it run ahead of the signed-byte
+    reading without swallowing that form's values.
+    """
+    for separator in _HEX_SEPARATORS:
+        if separator not in value:
+            continue
+        tokens = value.split(separator)
+        if len(tokens) != AES_KEY_LENGTH:
+            continue
+        if not all(len(token) == 2 for token in tokens):
+            continue
+        try:
+            return bytes.fromhex("".join(tokens))
+        except ValueError:
+            continue
+    return None
+
+
+def _key_from_hex(value: str) -> bytes | None:
+    """Decode "0f1e2d...", or a delimited form the strict decoder rejected."""
+    for separator in _HEX_SEPARATORS:
+        value = value.replace(separator, "")
+    try:
+        key = bytes.fromhex(value)
+    except ValueError:
+        return None
+    return key if len(key) == AES_KEY_LENGTH else None
+
+
+def _key_from_signed_bytes(value: str) -> bytes | None:
+    """Decode "-98,64,12,..." - Java's signed bytes, as its SDK prints them.
+
+    Runs ahead of `_key_from_hex` because it is the only form that gives `-` a
+    meaning other than "separator".
+    """
+    if "," not in value:
+        return None
+    try:
+        numbers = [int(part) for part in value.split(",")]
+    except ValueError:
+        return None
+    if len(numbers) != AES_KEY_LENGTH or any(not -128 <= n <= 255 for n in numbers):
+        return None
+    return bytes(n & 0xFF for n in numbers)
+
+
+def _key_from_base64(value: str) -> bytes | None:
+    """Decode standard base64."""
+    try:
+        key = base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error):
+        return None
+    return key if len(key) == AES_KEY_LENGTH else None
+
+
+def _cipher(aes_key: bytes) -> Cipher:
+    """Build the AES-128-CBC cipher TTLock uses, where the IV *is* the key.
+
+    Reusing the key as the IV is cryptographically poor, but it is what the
+    locks do, and interoperating means reproducing it exactly.
+    """
+    if len(aes_key) != AES_KEY_LENGTH:
+        raise ValueError(
+            f"TTLock AES keys are {AES_KEY_LENGTH} bytes, got {len(aes_key)}"
+        )
+    return Cipher(algorithms.AES(aes_key), modes.CBC(aes_key))
+
+
+def encrypt(aes_key: bytes, plaintext: bytes) -> bytes:
+    """Encrypt a frame payload for the lock."""
+    padder = padding.PKCS7(_AES_BLOCK_BITS).padder()
+    padded = padder.update(plaintext) + padder.finalize()
+    encryptor = _cipher(aes_key).encryptor()
+    return encryptor.update(padded) + encryptor.finalize()
+
+
+def decrypt(aes_key: bytes, ciphertext: bytes) -> bytes:
+    """Decrypt a frame payload from the lock.
+
+    Raises:
+        DecryptError: if the payload is not a whole number of blocks, or
+            unpads to nonsense - which in practice means a wrong key, since
+            CBC gives no other signal that we hold one.
+    """
+    if not ciphertext or len(ciphertext) % AES_KEY_LENGTH:
+        raise DecryptError(
+            f"Payload is {len(ciphertext)} bytes, not a whole number of AES blocks"
+        )
+
+    decryptor = _cipher(aes_key).decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+
+    unpadder = padding.PKCS7(_AES_BLOCK_BITS).unpadder()
+    try:
+        return unpadder.update(padded) + unpadder.finalize()
+    except ValueError as err:
+        raise DecryptError(
+            "Payload did not unpad; the AES key is probably wrong"
+        ) from err
+
+
+@dataclass(frozen=True)
+class LockVersion:
+    """The five envelope values identifying a lock's protocol dialect.
+
+    Not negotiated over the air - they arrive from `lock/detail`'s
+    `lockVersion` object, and every frame has to echo them back or the lock
+    ignores it.
+    """
+
+    protocol_type: int
+    protocol_version: int
+    scene: int
+    group_id: int
+    org_id: int
+
+    @classmethod
+    def from_cloud(cls, payload: dict) -> LockVersion:
+        """Build from a `lockVersion` object as the cloud API returns it.
+
+        Raises:
+            ValueError: if a key is missing - easier to diagnose than
+                silently defaulting to zeroes and having the lock drop every
+                frame without explanation.
+        """
+        try:
+            return cls(
+                protocol_type=payload["protocolType"],
+                protocol_version=payload["protocolVersion"],
+                scene=payload["scene"],
+                group_id=payload["groupId"],
+                org_id=payload["orgId"],
+            )
+        except KeyError as err:
+            raise ValueError(f"lockVersion is missing {err}") from err
+
+
+@dataclass(frozen=True)
+class Frame:
+    """One complete TTLock BLE frame.
+
+    Layout, 12-byte header then payload then 3-byte trailer:
+
+    ```
+     0-1  magic 7F 5A
+     2    protocol type     |
+     3    protocol version  |
+     4    scene             | LockVersion, echoed back on every frame
+     5-6  group id          |
+     7-8  org id            |
+     9    command
+     10   scramble key
+     11   payload length
+     12+  payload (encrypted when a key is supplied)
+     ...  CRC-8/MAXIM
+     ...  0D 0A
+    ```
+
+    `command` is a plain int, not `Command` - an unrecognised opcode should
+    arrive intact rather than raise. `data` is the payload in the clear;
+    encryption happens in `encode` and decryption in `decode`, so nothing
+    outside this module handles ciphertext. `scramble_key` is zero on the AES
+    locks this integration targets; older locks put an XOR seed there instead.
+    """
+
+    version: LockVersion
+    command: int
+    data: bytes = b""
+    scramble_key: int = 0
+
+    def encode(self, aes_key: bytes | None = None) -> bytes:
+        """Serialise to the bytes to write to the `fff2` characteristic.
+
+        Encrypts the payload when `aes_key` is given; omitting it produces a
+        cleartext frame, valid only for the handful of pre-session commands
+        that carry no secrets.
+
+        Raises:
+            ValueError: if the payload exceeds the one-byte length field.
+        """
+        payload = encrypt(aes_key, self.data) if aes_key is not None else self.data
+        if len(payload) > MAX_DATA_LENGTH:
+            raise ValueError(
+                f"Payload is {len(payload)} bytes; the length field holds at most {MAX_DATA_LENGTH}"
+            )
+
+        body = b"".join(
+            (
+                MAGIC,
+                bytes(
+                    (
+                        self.version.protocol_type,
+                        self.version.protocol_version,
+                        self.version.scene,
+                    )
+                ),
+                self.version.group_id.to_bytes(2, "big"),
+                self.version.org_id.to_bytes(2, "big"),
+                bytes((self.command, self.scramble_key, len(payload))),
+                payload,
+            )
+        )
+        return body + bytes((crc8_maxim(_checksummed(body)),)) + TERMINATOR
+
+    @classmethod
+    def decode(cls, raw: bytes, aes_key: bytes | None = None) -> Frame:
+        """Parse bytes received from the `fff4` characteristic.
+
+        Expects exactly one whole frame; use `FrameAssembler` to cut a stream
+        of GATT notifications into whole frames first.
+
+        Raises:
+            FrameError: on a malformed, truncated or over-long frame.
+            ChecksumError: on a CRC mismatch - a corrupt frame rather than a
+                foreign one, so at the edge of range it means "retry".
+            UnsupportedProtocol: if the lock used legacy XOR scrambling.
+            DecryptError: if `aes_key` does not decrypt the payload.
+        """
+        if len(raw) < HEADER_LENGTH + TRAILER_LENGTH:
+            raise FrameError(f"Frame is {len(raw)} bytes, too short to be one")
+        if not raw.startswith(MAGIC):
+            raise FrameError(f"Frame does not start with {MAGIC.hex()}")
+        if not raw.endswith(TERMINATOR):
+            raise FrameError(f"Frame does not end with {TERMINATOR.hex()}")
+
+        length = raw[11]
+        expected = HEADER_LENGTH + length + TRAILER_LENGTH
+        if len(raw) != expected:
+            raise FrameError(
+                f"Header declares a {length}-byte payload ({expected} bytes total), got {len(raw)}"
+            )
+
+        body = raw[: HEADER_LENGTH + length]
+        if (actual := raw[HEADER_LENGTH + length]) != (
+            want := crc8_maxim(_checksummed(body))
+        ):
+            # ChecksumError, not a fatal parse error: a single flipped bit on
+            # the air leaves magic, terminator and declared length all intact
+            # and fails only here, so this means retry. Safe to report - the
+            # header is public and the payload is ciphertext.
+            raise ChecksumError(
+                f"CRC is {actual:#04x}, expected {want:#04x}; frame was {raw.hex()}"
+            )
+
+        # A non-zero scramble key means legacy XOR obfuscation. Refusing loudly
+        # beats decrypting it as AES into plausible-looking garbage.
+        if scramble_key := raw[10]:
+            raise UnsupportedProtocol(
+                f"Lock is using legacy XOR scrambling (key {scramble_key:#04x}); only AES locks are supported"
+            )
+
+        payload = body[HEADER_LENGTH:]
+        return cls(
+            version=LockVersion(
+                protocol_type=raw[2],
+                protocol_version=raw[3],
+                scene=raw[4],
+                group_id=int.from_bytes(raw[5:7], "big"),
+                org_id=int.from_bytes(raw[7:9], "big"),
+            ),
+            command=raw[9],
+            data=decrypt(aes_key, payload)
+            if aes_key is not None and payload
+            else payload,
+            scramble_key=scramble_key,
+        )
+
+
+def _checksummed(body: bytes) -> bytes:
+    """Return the span of a frame the CRC-8 covers: header and payload.
+
+    Pulled out so `encode` and `decode` cannot drift apart on the span and
+    still agree with each other.
+    """
+    return body
+
+
+class FrameAssembler:
+    """Reassembles GATT notifications into whole frames.
+
+    A frame is up to 270 bytes but a BLE notification carries around 20, so
+    responses arrive in pieces and a single notification can carry the tail of
+    one frame and the head of the next. This holds the leftovers between
+    callbacks.
+
+    It resynchronises rather than failing: bytes before a `MAGIC` are dropped,
+    so starting mid-frame costs one frame, not the session. Stateful by
+    nature, so one instance belongs to one connection.
+    """
+
+    def __init__(self) -> None:
+        """Start with an empty buffer."""
+        self._buffer = bytearray()
+
+    def reset(self) -> None:
+        """Discard any partial frame. Call on connect and on disconnect."""
+        self._buffer.clear()
+
+    def feed(self, chunk: bytes) -> list[bytes]:
+        """Add received bytes, returning whichever frames are now complete.
+
+        Returns the raw bytes of each frame, still to be passed to
+        `Frame.decode` - keeping "where does a frame end" separate from "is
+        this frame valid" means a corrupt frame raises without desynchronising
+        the stream behind it.
+        """
+        self._buffer.extend(chunk)
+        frames: list[bytes] = []
+
+        while True:
+            start = self._buffer.find(MAGIC)
+            if start == -1:
+                # No frame start in sight. Keep the last byte: it could be the
+                # 0x7f of a magic split across two notifications.
+                del self._buffer[: max(0, len(self._buffer) - 1)]
+                break
+
+            del self._buffer[:start]
+
+            if len(self._buffer) < HEADER_LENGTH:
+                break
+
+            total = HEADER_LENGTH + self._buffer[11] + TRAILER_LENGTH
+            if len(self._buffer) < total:
+                break
+
+            frames.append(bytes(self._buffer[:total]))
+            del self._buffer[:total]
+
+        # No size cap needed: every path out bounds the buffer, and the
+        # one-byte length field caps a declared frame at MAX_FRAME_LENGTH.
+        return frames
+
+
+# The reply envelope: which command is being answered, then whether it worked.
+RESPONSE_COMMAND = 0
+RESPONSE_STATUS = 1
+RESPONSE_HEADER_LENGTH = 2
+RESPONSE_SUCCESS = 0x01
+
+
+@dataclass(frozen=True)
+class Response:
+    """The envelope every `RESPONSE` frame's payload carries.
+
+    An encrypted `QUERY_LOCK_STATUS` comes back as `14 01 64 00 01`: the
+    opcode just sent, then `0x01` for success, then command-specific data. So
+    a reply says what it answers and whether it worked before any payload.
+
+    `command` is a plain int for the same reason `Frame.command` is.
+    """
+
+    command: int | None
+    succeeded: bool | None
+    data: bytes
+
+    @classmethod
+    def parse(cls, payload: bytes) -> Response:
+        """Split a reply payload, tolerating one shorter than the envelope.
+
+        Never raises. A truncated reply reports `None` for what it did not
+        contain.
+        """
+        return cls(
+            command=payload[RESPONSE_COMMAND]
+            if len(payload) > RESPONSE_COMMAND
+            else None,
+            succeeded=(
+                payload[RESPONSE_STATUS] == RESPONSE_SUCCESS
+                if len(payload) > RESPONSE_STATUS
+                else None
+            ),
+            data=payload[RESPONSE_HEADER_LENGTH:],
+        )
+
+
+# `locked`/`door_open` follow models.SensorState (opened = 0, closed = 1),
+# which the cloud path already assumes. The standalone door-sensor product
+# documents the opposite mapping, but that is a separate accessory.
+_LOCKED_STATES = {0: True, 1: False}
+_DOOR_STATES = {0: True, 1: False}
+
+
+@dataclass(frozen=True)
+class LockStatus:
+    """What a lock reports about itself, read locally and unauthenticated.
+
+    The three bytes after the envelope, cross-checked against the cloud for
+    the same lock at the same moment: `64 00 01` against `electricQuantity:
+    100`, `state: 0` and `sensorState: 1`. `QUERY_LOCK_STATUS` is answered
+    without a session, so the local state read needs none of the
+    authentication built for changing state.
+
+    `door_open` is `None` on a lock that does not report a door; callers must
+    gate on the value being present rather than assuming a default.
+    """
+
+    battery: int | None
+    locked: bool | None
+    door_open: bool | None
+
+    @classmethod
+    def parse(cls, payload: bytes) -> LockStatus:
+        """Read a `QUERY_LOCK_STATUS` reply. Never raises; missing is `None`."""
+        data = Response.parse(payload).data
+        return cls(
+            battery=data[0] if len(data) > 0 else None,
+            locked=_LOCKED_STATES.get(data[1]) if len(data) > 1 else None,
+            door_open=_DOOR_STATES.get(data[2]) if len(data) > 2 else None,
+        )
+
+
+@dataclass(frozen=True)
+class DeviceFeatures:
+    """What a lock says about itself when asked with no credentials at all.
+
+    `SEARCH_DEVICE_FEATURE`'s reply, decoded off a KT170 against values the
+    cloud reported for the same lock:
+
+    ```
+    01                        opcode echoed
+    01                        success
+    64                        battery = 100
+    35 CC F5 F7               special_value
+    80 0C 2D 44               feature bits
+    00 00 00 00 00 00 00 00   still unidentified, zero on this lock
+    ```
+
+    The cloud reports `featureValue: "800C2D4435CCF5F7"` and `specialValue:
+    902624759` (= `0x35CCF5F7`), so `featureValue` is the feature bits and
+    `specialValue` concatenated, and the lock sends the same eight bytes with
+    the halves swapped - see `feature_value_bytes`. `extra` is the trailing
+    bytes nothing has identified yet, kept raw.
+    """
+
+    battery: int | None
+    feature_value: int | None
+    special_value: int | None
+    extra: bytes
+
+    @classmethod
+    def parse(cls, payload: bytes) -> DeviceFeatures:
+        """Read a `SEARCH_DEVICE_FEATURE` reply. Never raises; missing is `None`."""
+        data = Response.parse(payload).data
+        return cls(
+            battery=data[0] if len(data) > 0 else None,
+            special_value=int.from_bytes(data[1:5], "big") if len(data) >= 5 else None,
+            feature_value=int.from_bytes(data[5:9], "big") if len(data) >= 9 else None,
+            extra=data[9:],
+        )
+
+
+def feature_value_bytes(feature_value: str) -> bytes:
+    """The cloud's `featureValue` in the byte order the lock actually sends.
+
+    The two 32-bit halves swap - see `DeviceFeatures`. Anything comparing a
+    cloud `featureValue` against bytes off the radio has to go through here.
+    Returns empty for anything that is not the expected 16 hex digits, turning
+    a comparison off rather than failing it.
+    """
+    try:
+        raw = bytes.fromhex(feature_value)
+    except ValueError:
+        return b""
+    if len(raw) != 8:
+        return b""
+    return raw[4:] + raw[:4]

--- a/custom_components/ttlock/ble_protocol.py
+++ b/custom_components/ttlock/ble_protocol.py
@@ -33,11 +33,11 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 # Home Assistant core depends on it and pins a version, so declaring it here
 # could only conflict with that pin.
 
+# Start-of-frame marker. Also what the reassembler resynchronises on.
 MAGIC = b"\x7f\x5a"
-"""Start-of-frame marker. Also what the reassembler resynchronises on."""
 
+# CR+LF, the last two bytes of every frame.
 TERMINATOR = b"\x0d\x0a"
-"""CR+LF, the last two bytes of every frame."""
 
 HEADER_LENGTH = 12
 TRAILER_LENGTH = 3  # CRC-8 + CR + LF
@@ -47,18 +47,18 @@ MAX_FRAME_LENGTH = HEADER_LENGTH + MAX_DATA_LENGTH + TRAILER_LENGTH
 AES_KEY_LENGTH = 16
 _AES_BLOCK_BITS = 128
 
+# TTLock's proprietary GATT service - the one carrying command traffic.
 SERVICE_UUID = "00001910-0000-1000-8000-00805f9b34fb"
-"""TTLock's proprietary GATT service - the one carrying command traffic."""
 
+# Write-without-response characteristic. Commands go out here.
 WRITE_UUID = "0000fff2-0000-1000-8000-00805f9b34fb"
-"""Write-without-response characteristic. Commands go out here."""
 
+# Notify characteristic. Responses and unsolicited events arrive here.
 NOTIFY_UUID = "0000fff4-0000-1000-8000-00805f9b34fb"
-"""Notify characteristic. Responses and unsolicited events arrive here."""
 
+# Standard Battery Level characteristic - a one-byte read needing no key,
+# session or framing.
 BATTERY_UUID = "00002a19-0000-1000-8000-00805f9b34fb"
-"""Standard Battery Level characteristic - a one-byte read needing no key,
-session or framing."""
 
 
 class Command(IntEnum):

--- a/tests/const.py
+++ b/tests/const.py
@@ -53,6 +53,11 @@ BASIC_LOCK_DETAILS = {
     },
     "sensitivity": -1,
 }
+
+# The lockVersion object lock/detail returns, identifying the protocol dialect
+# every BLE frame must echo back. Matches BASIC_LOCK_DETAILS above.
+MOCK_LOCK_VERSION = BASIC_LOCK_DETAILS["lockVersion"]
+
 LOCK_DETAILS_WITH_SENSOR = {
     **BASIC_LOCK_DETAILS,
     "featureValue": "F44354CF5F3",

--- a/tests/test_ble_protocol.py
+++ b/tests/test_ble_protocol.py
@@ -1,0 +1,569 @@
+"""Tests for the pure BLE wire protocol.
+
+ble_protocol.py is the one part of the local transport provable without a
+lock, so these are the tests that have to be thorough - everything downstream
+assumes the bytes are right.
+
+Two kinds of assertion here, and the distinction matters. Round-trip tests
+(encode then decode) prove self-consistency but would pass just as happily if
+both halves were wrong in the same way. So the pieces that can be checked
+against something outside this repo are: crc8_maxim against the published
+CRC-8/MAXIM check value, the cipher against an independently constructed ECB
+computation, and the parses against what a real KT170 sent for a state the
+cloud reported at the same moment. Those are the ones that would catch a
+genuinely wrong protocol.
+"""
+
+import base64
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+import pytest
+
+from custom_components.ttlock.ble_protocol import (
+    HEADER_LENGTH,
+    MAGIC,
+    MAX_DATA_LENGTH,
+    TERMINATOR,
+    ChecksumError,
+    Command,
+    DecryptError,
+    DeviceFeatures,
+    Frame,
+    FrameAssembler,
+    FrameError,
+    LockStatus,
+    LockVersion,
+    Response,
+    UnsupportedProtocol,
+    crc8_maxim,
+    decrypt,
+    encrypt,
+    feature_value_bytes,
+    parse_aes_key,
+)
+
+from .const import MOCK_LOCK_VERSION
+
+KEY = bytes(range(16))
+VERSION = LockVersion(
+    protocol_type=5, protocol_version=3, scene=2, group_id=10, org_id=34
+)
+
+#: What a real KT170 answered an encrypted QUERY_LOCK_STATUS with, byte for
+#: byte. The lock was locked, its door shut, and the cloud said
+#: `electricQuantity: 100`, `state: 0`, `sensorState: 1` at the same moment -
+#: which is what decoded it, and what these tests are really asserting.
+KT170_STATUS_REPLY = bytes([0x14, 0x01, 0x64, 0x00, 0x01])
+
+#: What the same lock answered a *cleartext* SEARCH_DEVICE_FEATURE with, after
+#: decryption. The cloud said `electricQuantity: 100`,
+#: `featureValue: "800C2D4435CCF5F7"` and `specialValue: 902624759` for the
+#: same lock at the same moment, and 902624759 is 0x35CCF5F7 exactly.
+KT170_FEATURE_REPLY = bytes.fromhex("01016435ccf5f7800c2d440000000000000000")
+
+#: What `lock/detail` reported for that lock, verbatim.
+KT170_FEATURE_VALUE = "800C2D4435CCF5F7"
+KT170_SPECIAL_VALUE = 902624759
+
+
+class TestCrc8Maxim:
+    def test_the_published_check_value(self):
+        """Every CRC-8/MAXIM implementation agrees on this one."""
+        assert crc8_maxim(b"123456789") == 0xA1
+
+    def test_no_bytes(self):
+        assert crc8_maxim(b"") == 0
+
+    def test_a_single_zero_byte(self):
+        """Distinguishes MAXIM from variants with a non-zero init."""
+        assert crc8_maxim(b"\x00") == 0
+
+    def test_it_is_not_a_sum(self):
+        """Byte order has to matter, or it isn't a CRC at all."""
+        assert crc8_maxim(b"\x01\x02") != crc8_maxim(b"\x02\x01")
+
+    def test_it_stays_within_a_byte(self):
+        assert all(0 <= crc8_maxim(bytes([n])) <= 0xFF for n in range(256))
+
+
+class TestParseAesKey:
+    """aesKeyStr's encoding is undocumented, so every plausible one parses."""
+
+    def test_hex(self):
+        assert parse_aes_key(KEY.hex()) == KEY
+
+    def test_upper_case_hex(self):
+        assert parse_aes_key(KEY.hex().upper()) == KEY
+
+    @pytest.mark.parametrize("separator", [":", "-", ",", ".", " "])
+    def test_delimited_hex(self, separator):
+        assert parse_aes_key(separator.join(f"{b:02x}" for b in KEY)) == KEY
+
+    def test_the_shape_a_real_lock_returned(self):
+        """A KT170's aesKeyStr is 47 characters: 32 hex digits and 15 commas."""
+        delimited = ",".join(f"{b:02x}" for b in KEY)
+
+        assert len(delimited) == 47
+        assert parse_aes_key(delimited) == KEY
+
+    def test_all_numeric_hex_is_not_read_as_a_byte_list(self):
+        """The collision that hardware turned from theoretical into relevant.
+
+        "12,34,..." is a valid reading as comma-delimited hex *and* as a list
+        of decimal bytes, and the two give different keys. Nothing in the
+        string distinguishes them, so the tie is broken by evidence: a real
+        KT170 sends comma-delimited hex, and a key silently decoded as the
+        other form would fail on the air with no diagnosis to offer.
+        """
+        key = bytes([0x12, 0x34, 0x56, 0x78] * 4)
+        delimited = ",".join(f"{b:02x}" for b in key)
+
+        assert all(token.isdigit() for token in delimited.split(","))
+        assert parse_aes_key(delimited) == key
+
+    def test_a_negative_value_is_not_read_as_a_separator(self):
+        """The one way the two forms could collide, and the reason for the order.
+
+        Stripping "-" as a separator before trying the signed-byte list would
+        turn every negative into its absolute value - still 16 bytes, still
+        parsing cleanly, and wrong.
+        """
+        key = bytes([0x80] + [0x01] * 15)
+        signed = ",".join(str(b - 256 if b > 127 else b) for b in key)
+
+        assert parse_aes_key(signed) == key
+
+    def test_base64(self):
+        assert parse_aes_key(base64.b64encode(KEY).decode()) == KEY
+
+    def test_javas_signed_bytes(self):
+        """Java has no unsigned byte, so its SDK prints 0x80-0xff as negatives."""
+        key = bytes([0x80, 0xFF, 0x00, 0x7F] * 4)
+        signed = ",".join(str(b - 256 if b > 127 else b) for b in key)
+
+        assert parse_aes_key(signed) == key
+
+    def test_unsigned_decimal_bytes_too(self):
+        """Some tools print the same list without wrapping to signed."""
+        key = bytes([0x80, 0xFF, 0x00, 0x7F] * 4)
+
+        assert parse_aes_key(",".join(str(b) for b in key)) == key
+
+    def test_surrounding_whitespace(self):
+        assert parse_aes_key(f"  {KEY.hex()}\n") == KEY
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "   ",
+            "not a key at all",
+            "0f1e2d",  # valid hex, wrong length
+            "1,2,3",  # valid list, wrong length
+            "300,1,2",
+        ],
+    )
+    def test_anything_else_is_rejected(self, value):
+        """Wrong beats plausible: a mis-decoded key fails silently on the air."""
+        with pytest.raises(ValueError):
+            parse_aes_key(value)
+
+
+class TestCipher:
+    def test_the_iv_is_the_key(self):
+        """TTLock's defining cipher quirk, checked without reusing encrypt().
+
+        CBC XORs the IV into the first block before the block cipher runs, so
+        if the IV really is the key, the first ciphertext block must equal
+        ECB(key, plaintext XOR key).
+        """
+        plaintext = b"sixteen bytes!!!"
+
+        ecb = Cipher(algorithms.AES(KEY), modes.ECB()).encryptor()
+        expected = (
+            ecb.update(bytes(p ^ k for p, k in zip(plaintext, KEY, strict=True)))
+            + ecb.finalize()
+        )
+
+        assert encrypt(KEY, plaintext)[:16] == expected
+
+    def test_round_trip(self):
+        assert decrypt(KEY, encrypt(KEY, b"payload")) == b"payload"
+
+    def test_round_trip_of_an_exact_block(self):
+        """PKCS7 adds a whole extra block here - the case that trips zero-padding."""
+        plaintext = b"sixteen bytes!!!"
+
+        assert len(encrypt(KEY, plaintext)) == 32
+        assert decrypt(KEY, encrypt(KEY, plaintext)) == plaintext
+
+    def test_round_trip_of_nothing(self):
+        assert decrypt(KEY, encrypt(KEY, b"")) == b""
+
+    def test_the_wrong_key_is_rejected_rather_than_returning_rubbish(self):
+        ciphertext = encrypt(KEY, b"payload")
+
+        with pytest.raises(DecryptError):
+            decrypt(bytes(16), ciphertext)
+
+    def test_a_partial_block_is_rejected(self):
+        with pytest.raises(DecryptError):
+            decrypt(KEY, b"not a block")
+
+    def test_an_empty_payload_is_rejected(self):
+        with pytest.raises(DecryptError):
+            decrypt(KEY, b"")
+
+    @pytest.mark.parametrize("length", [8, 15, 17, 32])
+    def test_keys_must_be_16_bytes(self, length):
+        with pytest.raises(ValueError, match="16 bytes"):
+            encrypt(bytes(length), b"payload")
+
+
+class TestLockVersion:
+    def test_from_the_cloud_payload(self):
+        assert LockVersion.from_cloud(MOCK_LOCK_VERSION) == VERSION
+
+    def test_a_missing_field_is_named(self):
+        payload = {k: v for k, v in MOCK_LOCK_VERSION.items() if k != "orgId"}
+
+        with pytest.raises(ValueError, match="orgId"):
+            LockVersion.from_cloud(payload)
+
+
+class TestFrameEncoding:
+    def test_the_header_lays_out_as_documented(self):
+        raw = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"hi").encode()
+
+        assert raw[:2] == MAGIC
+        assert raw[2] == 5  # protocol type
+        assert raw[3] == 3  # protocol version
+        assert raw[4] == 2  # scene
+        assert raw[5:7] == (10).to_bytes(2, "big")  # group id
+        assert raw[7:9] == (34).to_bytes(2, "big")  # org id
+        assert raw[9] == Command.QUERY_LOCK_STATUS
+        assert raw[10] == 0  # scramble key: AES locks leave this clear
+        assert raw[11] == 2  # payload length
+        assert raw[HEADER_LENGTH : HEADER_LENGTH + 2] == b"hi"
+        assert raw[-2:] == TERMINATOR
+
+    def test_the_declared_length_is_of_the_ciphertext_not_the_plaintext(self):
+        """The lock counts the bytes on the wire, which padding makes longer."""
+        raw = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"hi").encode(KEY)
+
+        assert raw[11] == 16
+        assert len(raw) == HEADER_LENGTH + 16 + 3
+
+    def test_round_trip_in_the_clear(self):
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"probe")
+
+        assert Frame.decode(frame.encode()) == frame
+
+    def test_round_trip_encrypted(self):
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"secret payload")
+
+        assert Frame.decode(frame.encode(KEY), KEY) == frame
+
+    def test_an_empty_payload_round_trips_encrypted(self):
+        """Padding means even nothing becomes a block - decode must undo that."""
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS)
+
+        assert Frame.decode(frame.encode(KEY), KEY) == frame
+
+    def test_an_unknown_opcode_survives_the_round_trip(self):
+        """Command is a partial list; a lock may use one we haven't named."""
+        frame = Frame(VERSION, 0xFE, b"?")
+
+        assert Frame.decode(frame.encode()).command == 0xFE
+
+    def test_an_oversized_payload_is_refused(self):
+        with pytest.raises(ValueError, match="length field"):
+            Frame(
+                VERSION, Command.QUERY_LOCK_STATUS, bytes(MAX_DATA_LENGTH + 1)
+            ).encode()
+
+    def test_the_largest_payload_that_fits_is_allowed(self):
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS, bytes(MAX_DATA_LENGTH))
+
+        assert Frame.decode(frame.encode()) == frame
+
+
+class TestFrameDecoding:
+    @pytest.fixture
+    def raw(self) -> bytes:
+        return Frame(VERSION, Command.QUERY_LOCK_STATUS, b"payload").encode()
+
+    def test_a_corrupted_payload_is_caught_by_the_crc(self, raw):
+        tampered = bytearray(raw)
+        tampered[HEADER_LENGTH] ^= 0xFF
+
+        with pytest.raises(ChecksumError):
+            Frame.decode(bytes(tampered))
+
+    def test_the_frame_that_failed_comes_with_the_complaint(self, raw):
+        """Two readings of a CRC failure, and only the bytes separate them.
+
+        Hardware produced one that passed the magic, the terminator and the
+        declared length - so not a byte corrupted in flight, which would have
+        broken the alignment as well. The header in the reported frame says
+        whether the assembler cut in the wrong place.
+        """
+        tampered = bytearray(raw)
+        tampered[HEADER_LENGTH] ^= 0xFF
+
+        with pytest.raises(ChecksumError, match=bytes(tampered).hex()):
+            Frame.decode(bytes(tampered))
+
+    def test_a_corrupted_header_is_caught_by_the_crc(self, raw):
+        tampered = bytearray(raw)
+        tampered[4] ^= 0xFF  # scene
+
+        with pytest.raises(ChecksumError):
+            Frame.decode(bytes(tampered))
+
+    def test_a_bad_magic_is_rejected(self, raw):
+        with pytest.raises(FrameError, match="start with"):
+            Frame.decode(b"\x00\x00" + raw[2:])
+
+    def test_a_missing_terminator_is_rejected(self, raw):
+        with pytest.raises(FrameError, match="end with"):
+            Frame.decode(raw[:-2] + b"\x00\x00")
+
+    def test_too_few_bytes_to_be_a_frame(self):
+        with pytest.raises(FrameError, match="too short"):
+            Frame.decode(MAGIC + bytes(5))
+
+    def test_a_length_that_disagrees_with_the_frame_is_rejected(self, raw):
+        """Catches a truncated frame that happens to end in CR+LF."""
+        lying = bytearray(raw)
+        lying[11] += 1
+
+        with pytest.raises(FrameError, match="declares"):
+            Frame.decode(bytes(lying))
+
+    def test_legacy_xor_locks_are_refused_loudly(self):
+        """Decoding these as AES would yield convincing garbage."""
+        raw = Frame(
+            VERSION, Command.QUERY_LOCK_STATUS, b"payload", scramble_key=0x42
+        ).encode()
+
+        with pytest.raises(UnsupportedProtocol, match="0x42"):
+            Frame.decode(raw)
+
+    def test_the_wrong_key_surfaces_as_a_decrypt_error(self):
+        """Distinct from ChecksumError: the frame arrived intact, we just can't read it."""
+        raw = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"payload").encode(KEY)
+
+        with pytest.raises(DecryptError):
+            Frame.decode(raw, bytes(16))
+
+
+class TestFrameAssembler:
+    @pytest.fixture
+    def assembler(self) -> FrameAssembler:
+        return FrameAssembler()
+
+    @pytest.fixture
+    def frame(self) -> bytes:
+        """A frame longer than one BLE notification, as a real one would be.
+
+        An encrypted payload is a whole number of 16-byte blocks, so the
+        shortest real frame is 12 + 16 + 3 = 31 bytes - already too big for a
+        single ~20-byte notification. Reassembly is the normal case here, not
+        the edge case, so the fixture has to be long enough to need it.
+        """
+        return Frame(VERSION, Command.QUERY_LOCK_STATUS, b"state").encode(KEY)
+
+    def test_a_whole_frame_fed_in_one_piece(self, assembler, frame):
+        assert assembler.feed(frame) == [frame]
+
+    def test_nothing_is_emitted_until_the_frame_is_complete(self, assembler, frame):
+        assert assembler.feed(frame[:-1]) == []
+        assert assembler.feed(frame[-1:]) == [frame]
+
+    def test_a_frame_split_across_twenty_byte_notifications(self, assembler, frame):
+        """The real case: a BLE notification carries about 20 bytes."""
+        chunks = [frame[i : i + 20] for i in range(0, len(frame), 20)]
+        assert len(chunks) > 1
+
+        emitted = [f for chunk in chunks for f in assembler.feed(chunk)]
+
+        assert emitted == [frame]
+
+    def test_two_frames_arriving_together(self, assembler, frame):
+        assert assembler.feed(frame + frame) == [frame, frame]
+
+    def test_a_notification_carrying_the_tail_of_one_frame_and_the_head_of_the_next(
+        self, assembler, frame
+    ):
+        assembler.feed((frame + frame)[:-5])
+
+        assert assembler.feed(frame[-5:]) == [frame]
+
+    def test_it_resynchronises_past_leading_junk(self, assembler, frame):
+        """Connecting mid-response shouldn't cost more than the frame in flight."""
+        assert assembler.feed(b"\x11\x22\x33" + frame) == [frame]
+
+    def test_a_magic_split_across_two_notifications(self, assembler, frame):
+        """The one byte the buffer must hold on to when it sees no frame start."""
+        assembler.feed(b"junk" + frame[:1])
+
+        assert assembler.feed(frame[1:]) == [frame]
+
+    def test_magic_free_noise_does_not_accumulate(self, assembler, frame):
+        for _ in range(50):
+            assert assembler.feed(bytes(20)) == []
+
+        assert assembler.feed(frame) == [frame]
+
+    def test_a_corrupt_frame_does_not_desynchronise_what_follows(
+        self, assembler, frame
+    ):
+        """Cutting the stream up is kept separate from validating it, for this."""
+        corrupt = bytearray(frame)
+        corrupt[HEADER_LENGTH] ^= 0xFF
+
+        emitted = assembler.feed(bytes(corrupt) + frame)
+
+        assert len(emitted) == 2
+        with pytest.raises(ChecksumError):
+            Frame.decode(emitted[0])
+        assert Frame.decode(emitted[1]) == Frame.decode(frame)
+
+    def test_reset_drops_a_partial_frame(self, assembler, frame):
+        assembler.feed(frame[:8])
+
+        assembler.reset()
+
+        assert assembler.feed(frame[8:]) == []
+
+
+class TestResponse:
+    """The reply envelope: which command, then whether it worked."""
+
+    def test_the_reply_a_real_lock_sent(self):
+        response = Response.parse(KT170_STATUS_REPLY)
+
+        assert response.command == Command.QUERY_LOCK_STATUS
+        assert response.succeeded is True
+        assert response.data == b"\x64\x00\x01"
+
+    def test_a_refusal(self):
+        response = Response.parse(bytes([0x41, 0x00]))
+
+        assert response.command == 0x41
+        assert response.succeeded is False
+        assert response.data == b""
+
+    def test_an_unrecognised_opcode_arrives_intact(self):
+        """Same rule as Frame.command - decode it, do not raise over it."""
+        assert Response.parse(b"\xfe\x01").command == 0xFE
+
+    def test_a_truncated_reply_claims_nothing(self):
+        response = Response.parse(b"")
+
+        assert response.command is None
+        assert response.succeeded is None
+        assert response.data == b""
+
+
+class TestLockStatus:
+    """The parse that made an authenticated session unnecessary for M2."""
+
+    def test_the_reply_a_real_lock_sent(self):
+        """Three values, each confirmed against the cloud's answer for the
+        same lock at the same moment. That agreement is the whole proof.
+        """
+        status = LockStatus.parse(KT170_STATUS_REPLY)
+
+        assert status.battery == 100
+        assert status.locked is True
+        assert status.door_open is False
+
+    def test_an_unlocked_lock(self):
+        status = LockStatus.parse(bytes([0x14, 0x01, 0x50, 0x01, 0x00]))
+
+        assert status.battery == 80
+        assert status.locked is False
+        assert status.door_open is True
+
+    def test_an_unknown_state_is_not_reported_as_either(self):
+        """2 is the cloud's "unknown", and guessing it is how a shut door gets
+        reported as open.
+        """
+        status = LockStatus.parse(bytes([0x14, 0x01, 0x64, 0x02, 0x02]))
+
+        assert status.battery == 100
+        assert status.locked is None
+        assert status.door_open is None
+
+    def test_a_lock_with_no_door_sensor_says_nothing_about_one(self):
+        status = LockStatus.parse(bytes([0x14, 0x01, 0x64, 0x00]))
+
+        assert status.locked is True
+        assert status.door_open is None
+
+    def test_an_empty_reply_does_not_raise(self):
+        assert LockStatus.parse(b"") == LockStatus(None, None, None)
+
+
+class TestDeviceFeatures:
+    """The other unauthenticated reply, and the endianness it exposed."""
+
+    def test_the_reply_a_real_lock_sent(self):
+        """Every field cross-checked against `lock/detail` for the same lock.
+
+        That agreement is the proof, not the parse: three independent values
+        the cloud reported separately all land where this says they should.
+        """
+        features = DeviceFeatures.parse(KT170_FEATURE_REPLY)
+
+        assert features.battery == 100
+        assert features.special_value == KT170_SPECIAL_VALUE
+        assert features.feature_value == 0x800C2D44
+        assert features.extra == bytes(8)
+
+    def test_the_cloud_s_feature_value_is_two_numbers(self):
+        """The find. `featureValue` is the feature bits and `specialValue`
+        concatenated - which is why the halves have to be swapped to compare
+        it against anything off the radio.
+        """
+        features = DeviceFeatures.parse(KT170_FEATURE_REPLY)
+        assert features.feature_value is not None
+        assert features.special_value is not None
+
+        combined = (features.feature_value << 32) | features.special_value
+
+        assert combined == int(KT170_FEATURE_VALUE, 16)
+
+    def test_a_truncated_reply_reports_unknown_rather_than_raising(self):
+        features = DeviceFeatures.parse(bytes([0x01, 0x01, 0x64]))
+
+        assert features.battery == 100
+        assert features.special_value is None
+        assert features.feature_value is None
+
+    def test_an_empty_reply_does_not_raise(self):
+        assert DeviceFeatures.parse(b"") == DeviceFeatures(None, None, None, b"")
+
+
+class TestFeatureValueBytes:
+    """The swap, isolated - it is the whole of a check that must not lie."""
+
+    def test_it_matches_what_the_lock_actually_sent(self):
+        """Before this, a comparison read false on a payload that had decrypted
+        perfectly: a false negative on the one check proving the key encoding,
+        the IV convention, the cipher mode and the padding.
+        """
+        expected = feature_value_bytes(KT170_FEATURE_VALUE)
+
+        assert expected in KT170_FEATURE_REPLY
+
+    def test_the_cloud_s_own_byte_order_is_not_in_the_reply(self):
+        """The failure this replaced, kept so a revert cannot pass quietly."""
+        assert bytes.fromhex(KT170_FEATURE_VALUE) not in KT170_FEATURE_REPLY
+
+    @pytest.mark.parametrize("value", ["", "not hex", "800C2D44", "800C2D4435CCF5F7FF"])
+    def test_anything_unexpected_turns_the_check_off(self, value):
+        """Empty disables the comparison; raising would fail a dump over it."""
+        assert feature_value_bytes(value) == b""


### PR DESCRIPTION
Third slice of #325 — the first half of M2. A pure, I/O-free module for the read-only part of the TTLock BLE protocol, plus its tests. Nothing calls it yet; the GATT session that will (`ble.py` + coordinator merge) is the next PR, kept separate so this can be reviewed as protocol code on its own.

## What's in it

`custom_components/ttlock/ble_protocol.py`:

- Framing: `7f 5a` magic, 12-byte header echoing `lockVersion`, one-byte length, CRC-8/MAXIM, `0d 0a` terminator. `Frame.encode` / `Frame.decode`.
- `FrameAssembler` — cuts a stream of ~20-byte GATT notifications into whole frames, resynchronising past junk.
- AES-128-CBC with the key reused as IV (what the locks do), PKCS7 padding.
- `parse_aes_key` — `lock/detail`'s `aesKeyStr` is undocumented and appears as hex, delimited hex, base64 or Java signed bytes in the wild; each is accepted only if it yields exactly 16 bytes.
- `Response`, `LockStatus` (battery / locked / door), `DeviceFeatures` — the two replies a lock answers **without** a session, which is what makes a local state read possible on developer credentials alone.

Scope is deliberately reading-only: no auth or write opcodes, per the discussion — the BLE write path isn't reachable with developer credentials.

## Tests

84 tests in `tests/test_ble_protocol.py`. CRC and cipher are checked against external references (published CRC-8/MAXIM check value; an independent ECB construction), not just round-tripped. Reply vectors are from a KT170, cross-checked against the cloud's `electricQuantity` / `state` / `sensorState` / `featureValue` / `specialValue` for the same lock at the same moment.

`script/check` clean, 381 passed.

`cryptography` is used but not added to `manifest.json` requirements — HA core depends on and pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
