### PR TITLE
ble: read lock state locally over GATT, cloud as fallback

### DIFF
--- a/custom_components/ttlock/ble.py
+++ b/custom_components/ttlock/ble.py
@@ -1,12 +1,16 @@
-"""Local Bluetooth presence for TTLock locks.
+"""Local Bluetooth presence and state reads for TTLock locks.
 
-Read-only, passive layer that listens for the advertisements the lock is
-broadcasting anyway.
+Presence is passive - the advertisements the lock is broadcasting anyway. A
+state read opens a short GATT session, which wakes the lock's radio, so it is
+only ever driven by the coordinator's poll. The wire format lives in
+ble_protocol.py; this module owns the connection around it.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
@@ -15,13 +19,51 @@ from typing import TYPE_CHECKING
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
+from .ble_protocol import (
+    NOTIFY_UUID,
+    WRITE_UUID,
+    Command,
+    Frame,
+    FrameAssembler,
+    LockStatus,
+    LockVersion,
+)
+
 if TYPE_CHECKING:
+    from bleak import BleakClient
+
     from homeassistant.components.bluetooth import (
         BluetoothChange,
         BluetoothServiceInfoBleak,
     )
 
 _LOGGER = logging.getLogger(__name__)
+
+# The poll is the only caller and has the cloud behind it, so give up early
+# rather than hold the poll for a lock that isn't answering.
+CONNECT_TIMEOUT = 15.0
+CONNECT_ATTEMPTS = 3
+RESPONSE_TIMEOUT = 10.0
+
+# Writes are split to the negotiated MTU minus the ATT write header.
+DEFAULT_MTU = 23
+_ATT_WRITE_OVERHEAD = 3
+
+
+class BleError(Exception):
+    """Base for local Bluetooth failures."""
+
+
+class BleNotInRange(BleError):
+    """No connectable adapter or proxy can currently reach the lock."""
+
+
+class BleConnectionError(BleError):
+    """Connecting, subscribing or writing failed."""
+
+
+class BleNoResponse(BleError):
+    """The lock took a command and never answered."""
 
 
 @dataclass
@@ -136,3 +178,182 @@ def async_track_address(
             unsubscribe()
 
     return _unsubscribe
+
+
+async def async_connect(
+    hass: HomeAssistant, address: str, name: str, timeout: float | None = None
+) -> BleakClient:
+    """Open a GATT connection to the lock via whichever adapter can reach it."""
+    from bleak_retry_connector import (  # noqa: PLC0415
+        BleakClientWithServiceCache,
+        BleakError,
+        establish_connection,
+    )
+
+    from homeassistant.components import bluetooth  # noqa: PLC0415
+
+    if timeout is None:
+        timeout = CONNECT_TIMEOUT
+
+    device = bluetooth.async_ble_device_from_address(hass, address, connectable=True)
+    if device is None:
+        raise BleNotInRange(
+            f"{name} is not reachable over Bluetooth from this Home Assistant instance"
+        )
+
+    try:
+        async with asyncio.timeout(timeout):
+            return await establish_connection(
+                BleakClientWithServiceCache,
+                device,
+                name,
+                max_attempts=CONNECT_ATTEMPTS,
+            )
+    except TimeoutError as err:
+        raise BleConnectionError(
+            f"Timed out connecting to {name} after {timeout:.0f}s"
+        ) from err
+    except BleakError as err:
+        raise BleConnectionError(f"Could not connect to {name}: {err}") from err
+
+
+async def async_disconnect(client: BleakClient, name: str) -> None:
+    """Close the connection, never raising - there is nothing left to do about it."""
+    from bleak_retry_connector import BleakError  # noqa: PLC0415
+
+    try:
+        await client.disconnect()
+    except BleakError as err:
+        _LOGGER.debug("Disconnecting from %s failed: %s", name, err)
+
+
+class LockSession:
+    """One request/response conversation over an open connection.
+
+    Commands are serialised: a frame arriving while one is pending is its
+    answer, anything else is dropped.
+    """
+
+    def __init__(
+        self,
+        client: BleakClient,
+        name: str,
+        version: LockVersion,
+        aes_key: bytes | None = None,
+    ) -> None:
+        """Wrap an already-connected client; `start` subscribes to replies."""
+        self._client = client
+        self._name = name
+        self._version = version
+        self._aes_key = aes_key
+        self._assembler = FrameAssembler()
+        self._pending: asyncio.Future[bytes] | None = None
+        self._turn = asyncio.Lock()
+
+    async def start(self) -> None:
+        """Subscribe to the lock's replies; must precede the first command."""
+        from bleak_retry_connector import BleakError  # noqa: PLC0415
+
+        try:
+            await self._client.start_notify(NOTIFY_UUID, self._notification)
+        except BleakError as err:
+            raise BleConnectionError(
+                f"Could not subscribe to notifications from {self._name}: {err}"
+            ) from err
+
+    async def stop(self) -> None:
+        """Unsubscribe, never raising."""
+        from bleak_retry_connector import BleakError  # noqa: PLC0415
+
+        try:
+            await self._client.stop_notify(NOTIFY_UUID)
+        except BleakError as err:
+            _LOGGER.debug("Unsubscribing from %s failed: %s", self._name, err)
+
+    async def execute(
+        self, command: Command, data: bytes = b"", *, encrypted: bool = True
+    ) -> Frame:
+        """Send one command and return the lock's decoded reply."""
+        aes_key = self._aes_key if encrypted else None
+        if encrypted and aes_key is None:
+            raise BleError(
+                f"{self._name} has no AES key, so command {int(command)} cannot be sent"
+            )
+
+        async with self._turn:
+            self._assembler.reset()
+            pending = asyncio.get_running_loop().create_future()
+            self._pending = pending
+            try:
+                await self._write(
+                    Frame(self._version, command, data).encode(aes_key=aes_key)
+                )
+                async with asyncio.timeout(RESPONSE_TIMEOUT):
+                    raw = await pending
+            except TimeoutError as err:
+                raise BleNoResponse(
+                    f"{self._name} did not answer command {int(command)} "
+                    f"within {RESPONSE_TIMEOUT:.0f}s"
+                ) from err
+            finally:
+                self._pending = None
+
+        return Frame.decode(raw, aes_key=aes_key)
+
+    async def _write(self, payload: bytes) -> None:
+        from bleak_retry_connector import BleakError  # noqa: PLC0415
+
+        mtu = getattr(self._client, "mtu_size", None) or DEFAULT_MTU
+        size = max(DEFAULT_MTU, mtu) - _ATT_WRITE_OVERHEAD
+        try:
+            for offset in range(0, len(payload), size):
+                await self._client.write_gatt_char(
+                    WRITE_UUID, payload[offset : offset + size], response=False
+                )
+        except BleakError as err:
+            raise BleConnectionError(f"Could not write to {self._name}: {err}") from err
+
+    @callback
+    def _notification(self, _characteristic: object, data: bytearray) -> None:
+        for raw in self._assembler.feed(bytes(data)):
+            pending = self._pending
+            if pending is None or pending.done():
+                _LOGGER.debug("Discarding an unexpected frame from %s", self._name)
+                continue
+            pending.set_result(raw)
+
+
+@asynccontextmanager
+async def async_command_session(
+    hass: HomeAssistant,
+    address: str,
+    name: str,
+    version: LockVersion,
+    aes_key: bytes | None = None,
+) -> AsyncIterator[LockSession]:
+    """Connect, subscribe, yield a session, and always disconnect after."""
+    client = await async_connect(hass, address, name)
+    session = LockSession(client, name, version, aes_key)
+    try:
+        await session.start()
+        yield session
+    finally:
+        await session.stop()
+        await async_disconnect(client, name)
+
+
+async def async_read_status(
+    hass: HomeAssistant,
+    address: str,
+    name: str,
+    version: LockVersion,
+    aes_key: bytes,
+) -> LockStatus:
+    """Read lock, battery and door state over one short session.
+
+    QUERY_LOCK_STATUS is encrypted with the AES key but needs no
+    authenticated session, so the key from lock/detail is all it takes.
+    """
+    async with async_command_session(hass, address, name, version, aes_key) as session:
+        reply = await session.execute(Command.QUERY_LOCK_STATUS)
+    return LockStatus.parse(reply.data)

--- a/custom_components/ttlock/ble_protocol.py
+++ b/custom_components/ttlock/ble_protocol.py
@@ -1,0 +1,629 @@
+"""Pure TTLock BLE wire protocol - framing, checksum, and encryption.
+
+Free of I/O by design: it turns Python values into bytes and back, with no
+bleak, Home Assistant, coroutines or clock. That is what lets it be tested
+without a lock present, and reused unchanged if the radio later moves from the
+HA host's own adapter to a proxy or gateway. `ble.py` owns the GATT session
+and calls in here.
+
+Provenance: not ported from any implementation. The public references -
+`kind3r/ttlock-sdk-js` (GPL-3.0), `Fusseldieb/ttlock-reverse-engineering` (no
+licence) and `roquerodrigo/ha-ttlock-ble` (MIT) - were read as documentation
+of the protocol. Field offsets, opcodes, the CRC variant and the cipher mode
+are interface facts and carry no copyright; the code here is written from
+those facts, so this MIT integration is not bound by the GPL reference.
+
+Secrets: nothing here logs. The AES key comes from `lock/detail`'s
+`aesKeyStr`, which `const.py` already redacts, so a debug line carrying a key,
+plaintext or decoded frame would leak it into a diagnostics upload. This
+module therefore has no logger, and callers must keep it that way.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from dataclasses import dataclass
+from enum import IntEnum
+
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# `cryptography` is deliberately absent from manifest.json's requirements:
+# Home Assistant core depends on it and pins a version, so declaring it here
+# could only conflict with that pin.
+
+MAGIC = b"\x7f\x5a"
+"""Start-of-frame marker. Also what the reassembler resynchronises on."""
+
+TERMINATOR = b"\x0d\x0a"
+"""CR+LF, the last two bytes of every frame."""
+
+HEADER_LENGTH = 12
+TRAILER_LENGTH = 3  # CRC-8 + CR + LF
+MAX_DATA_LENGTH = 0xFF  # the length field is one byte
+MAX_FRAME_LENGTH = HEADER_LENGTH + MAX_DATA_LENGTH + TRAILER_LENGTH
+
+AES_KEY_LENGTH = 16
+_AES_BLOCK_BITS = 128
+
+SERVICE_UUID = "00001910-0000-1000-8000-00805f9b34fb"
+"""TTLock's proprietary GATT service - the one carrying command traffic."""
+
+WRITE_UUID = "0000fff2-0000-1000-8000-00805f9b34fb"
+"""Write-without-response characteristic. Commands go out here."""
+
+NOTIFY_UUID = "0000fff4-0000-1000-8000-00805f9b34fb"
+"""Notify characteristic. Responses and unsolicited events arrive here."""
+
+BATTERY_UUID = "00002a19-0000-1000-8000-00805f9b34fb"
+"""Standard Battery Level characteristic - a one-byte read needing no key,
+session or framing."""
+
+
+class Command(IntEnum):
+    """The opcodes this integration needs, from the much longer full set.
+
+    Deliberately partial - an opcode is added only once something sends or
+    handles it. `Frame.command` is a plain int, so an unrecognised opcode is
+    decoded and passed on rather than raising; these members compare equal to
+    the matching int, so callers can still match on them.
+    """
+
+    SEARCH_DEVICE_FEATURE = 1
+    """Ask which features the lock supports. Cheap, unauthenticated probe."""
+
+    QUERY_LOCK_STATUS = 20
+    """Read locked/unlocked state - the local equivalent of a cloud poll."""
+
+    RESPONSE = 84
+    """Generic acknowledgement wrapper the lock replies with."""
+
+
+class ProtocolError(Exception):
+    """Base class for every failure to speak or understand the wire format."""
+
+
+class FrameError(ProtocolError):
+    """A byte sequence is not a well-formed frame."""
+
+
+class ChecksumError(FrameError):
+    """A frame's CRC-8 does not match its contents."""
+
+
+class DecryptError(ProtocolError):
+    """A frame's payload could not be decrypted with the key we hold."""
+
+
+class UnsupportedProtocol(ProtocolError):
+    """The lock is speaking a variant of the protocol we do not implement."""
+
+
+def crc8_maxim(data: bytes) -> int:
+    """Return the CRC-8/MAXIM checksum of `data`.
+
+    Polynomial 0x31, reflected in and out, zero init, zero xor-out. The
+    reflected form is implemented directly (shifting right against 0x8C).
+    """
+    crc = 0
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0x8C if crc & 1 else crc >> 1
+    return crc
+
+
+def parse_aes_key(value: str) -> bytes:
+    """Decode `lock/detail`'s `aesKeyStr` into the 16 raw key bytes.
+
+    The cloud does not document the field's encoding, and the public
+    reverse-engineering work disagrees: hex, separator-delimited hex, base64
+    and comma-separated signed Java bytes all appear. Each is tried and
+    accepted only if it yields exactly 16 bytes, rather than picking one and
+    producing silent garbage when wrong.
+
+    Comma-delimited hex and signed bytes are not mutually exclusive
+    ("12,34,..." is a valid reading of both, giving different keys), so the
+    order is structural: the strict delimited-hex reading claims only 16
+    two-hex-digit tokens - the shape a real lock sends - and anything a signed
+    list does that hex cannot (a minus sign, a one- or three-digit token)
+    falls through to the signed reading.
+
+    Raises:
+        ValueError: if the value matches no known encoding.
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError("aesKeyStr is empty")
+
+    for decode in (
+        _key_from_delimited_hex,
+        _key_from_signed_bytes,
+        _key_from_hex,
+        _key_from_base64,
+    ):
+        if (key := decode(value)) is not None:
+            return key
+
+    raise ValueError(
+        f"aesKeyStr is a {len(value)}-character string in an unrecognised encoding"
+    )
+
+
+# Separators seen between hex byte pairs. Space is absent deliberately:
+# bytes.fromhex already skips ASCII whitespace itself.
+_HEX_SEPARATORS = ":-,."
+
+
+def _key_from_delimited_hex(value: str) -> bytes | None:
+    """Decode "0f,1e,2d,..." - the form a real KT170 returns.
+
+    Strict where `_key_from_hex` is forgiving: insisting on 16 tokens of
+    exactly two hex digits is what lets it run ahead of the signed-byte
+    reading without swallowing that form's values.
+    """
+    for separator in _HEX_SEPARATORS:
+        if separator not in value:
+            continue
+        tokens = value.split(separator)
+        if len(tokens) != AES_KEY_LENGTH:
+            continue
+        if not all(len(token) == 2 for token in tokens):
+            continue
+        try:
+            return bytes.fromhex("".join(tokens))
+        except ValueError:
+            continue
+    return None
+
+
+def _key_from_hex(value: str) -> bytes | None:
+    """Decode "0f1e2d...", or a delimited form the strict decoder rejected."""
+    for separator in _HEX_SEPARATORS:
+        value = value.replace(separator, "")
+    try:
+        key = bytes.fromhex(value)
+    except ValueError:
+        return None
+    return key if len(key) == AES_KEY_LENGTH else None
+
+
+def _key_from_signed_bytes(value: str) -> bytes | None:
+    """Decode "-98,64,12,..." - Java's signed bytes, as its SDK prints them.
+
+    Runs ahead of `_key_from_hex` because it is the only form that gives `-` a
+    meaning other than "separator".
+    """
+    if "," not in value:
+        return None
+    try:
+        numbers = [int(part) for part in value.split(",")]
+    except ValueError:
+        return None
+    if len(numbers) != AES_KEY_LENGTH or any(not -128 <= n <= 255 for n in numbers):
+        return None
+    return bytes(n & 0xFF for n in numbers)
+
+
+def _key_from_base64(value: str) -> bytes | None:
+    """Decode standard base64."""
+    try:
+        key = base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error):
+        return None
+    return key if len(key) == AES_KEY_LENGTH else None
+
+
+def _cipher(aes_key: bytes) -> Cipher:
+    """Build the AES-128-CBC cipher TTLock uses, where the IV *is* the key.
+
+    Reusing the key as the IV is cryptographically poor, but it is what the
+    locks do, and interoperating means reproducing it exactly.
+    """
+    if len(aes_key) != AES_KEY_LENGTH:
+        raise ValueError(
+            f"TTLock AES keys are {AES_KEY_LENGTH} bytes, got {len(aes_key)}"
+        )
+    return Cipher(algorithms.AES(aes_key), modes.CBC(aes_key))
+
+
+def encrypt(aes_key: bytes, plaintext: bytes) -> bytes:
+    """Encrypt a frame payload for the lock."""
+    padder = padding.PKCS7(_AES_BLOCK_BITS).padder()
+    padded = padder.update(plaintext) + padder.finalize()
+    encryptor = _cipher(aes_key).encryptor()
+    return encryptor.update(padded) + encryptor.finalize()
+
+
+def decrypt(aes_key: bytes, ciphertext: bytes) -> bytes:
+    """Decrypt a frame payload from the lock.
+
+    Raises:
+        DecryptError: if the payload is not a whole number of blocks, or
+            unpads to nonsense - which in practice means a wrong key, since
+            CBC gives no other signal that we hold one.
+    """
+    if not ciphertext or len(ciphertext) % AES_KEY_LENGTH:
+        raise DecryptError(
+            f"Payload is {len(ciphertext)} bytes, not a whole number of AES blocks"
+        )
+
+    decryptor = _cipher(aes_key).decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+
+    unpadder = padding.PKCS7(_AES_BLOCK_BITS).unpadder()
+    try:
+        return unpadder.update(padded) + unpadder.finalize()
+    except ValueError as err:
+        raise DecryptError(
+            "Payload did not unpad; the AES key is probably wrong"
+        ) from err
+
+
+@dataclass(frozen=True)
+class LockVersion:
+    """The five envelope values identifying a lock's protocol dialect.
+
+    Not negotiated over the air - they arrive from `lock/detail`'s
+    `lockVersion` object, and every frame has to echo them back or the lock
+    ignores it.
+    """
+
+    protocol_type: int
+    protocol_version: int
+    scene: int
+    group_id: int
+    org_id: int
+
+    @classmethod
+    def from_cloud(cls, payload: dict) -> LockVersion:
+        """Build from a `lockVersion` object as the cloud API returns it.
+
+        Raises:
+            ValueError: if a key is missing - easier to diagnose than
+                silently defaulting to zeroes and having the lock drop every
+                frame without explanation.
+        """
+        try:
+            return cls(
+                protocol_type=payload["protocolType"],
+                protocol_version=payload["protocolVersion"],
+                scene=payload["scene"],
+                group_id=payload["groupId"],
+                org_id=payload["orgId"],
+            )
+        except KeyError as err:
+            raise ValueError(f"lockVersion is missing {err}") from err
+
+
+@dataclass(frozen=True)
+class Frame:
+    """One complete TTLock BLE frame.
+
+    Layout, 12-byte header then payload then 3-byte trailer:
+
+    ```
+     0-1  magic 7F 5A
+     2    protocol type     |
+     3    protocol version  |
+     4    scene             | LockVersion, echoed back on every frame
+     5-6  group id          |
+     7-8  org id            |
+     9    command
+     10   scramble key
+     11   payload length
+     12+  payload (encrypted when a key is supplied)
+     ...  CRC-8/MAXIM
+     ...  0D 0A
+    ```
+
+    `command` is a plain int, not `Command` - an unrecognised opcode should
+    arrive intact rather than raise. `data` is the payload in the clear;
+    encryption happens in `encode` and decryption in `decode`, so nothing
+    outside this module handles ciphertext. `scramble_key` is zero on the AES
+    locks this integration targets; older locks put an XOR seed there instead.
+    """
+
+    version: LockVersion
+    command: int
+    data: bytes = b""
+    scramble_key: int = 0
+
+    def encode(self, aes_key: bytes | None = None) -> bytes:
+        """Serialise to the bytes to write to the `fff2` characteristic.
+
+        Encrypts the payload when `aes_key` is given; omitting it produces a
+        cleartext frame, valid only for the handful of pre-session commands
+        that carry no secrets.
+
+        Raises:
+            ValueError: if the payload exceeds the one-byte length field.
+        """
+        payload = encrypt(aes_key, self.data) if aes_key is not None else self.data
+        if len(payload) > MAX_DATA_LENGTH:
+            raise ValueError(
+                f"Payload is {len(payload)} bytes; the length field holds at most {MAX_DATA_LENGTH}"
+            )
+
+        body = b"".join(
+            (
+                MAGIC,
+                bytes(
+                    (
+                        self.version.protocol_type,
+                        self.version.protocol_version,
+                        self.version.scene,
+                    )
+                ),
+                self.version.group_id.to_bytes(2, "big"),
+                self.version.org_id.to_bytes(2, "big"),
+                bytes((self.command, self.scramble_key, len(payload))),
+                payload,
+            )
+        )
+        return body + bytes((crc8_maxim(_checksummed(body)),)) + TERMINATOR
+
+    @classmethod
+    def decode(cls, raw: bytes, aes_key: bytes | None = None) -> Frame:
+        """Parse bytes received from the `fff4` characteristic.
+
+        Expects exactly one whole frame; use `FrameAssembler` to cut a stream
+        of GATT notifications into whole frames first.
+
+        Raises:
+            FrameError: on a malformed, truncated or over-long frame.
+            ChecksumError: on a CRC mismatch - a corrupt frame rather than a
+                foreign one, so at the edge of range it means "retry".
+            UnsupportedProtocol: if the lock used legacy XOR scrambling.
+            DecryptError: if `aes_key` does not decrypt the payload.
+        """
+        if len(raw) < HEADER_LENGTH + TRAILER_LENGTH:
+            raise FrameError(f"Frame is {len(raw)} bytes, too short to be one")
+        if not raw.startswith(MAGIC):
+            raise FrameError(f"Frame does not start with {MAGIC.hex()}")
+        if not raw.endswith(TERMINATOR):
+            raise FrameError(f"Frame does not end with {TERMINATOR.hex()}")
+
+        length = raw[11]
+        expected = HEADER_LENGTH + length + TRAILER_LENGTH
+        if len(raw) != expected:
+            raise FrameError(
+                f"Header declares a {length}-byte payload ({expected} bytes total), got {len(raw)}"
+            )
+
+        body = raw[: HEADER_LENGTH + length]
+        if (actual := raw[HEADER_LENGTH + length]) != (
+            want := crc8_maxim(_checksummed(body))
+        ):
+            # ChecksumError, not a fatal parse error: a single flipped bit on
+            # the air leaves magic, terminator and declared length all intact
+            # and fails only here, so this means retry. Safe to report - the
+            # header is public and the payload is ciphertext.
+            raise ChecksumError(
+                f"CRC is {actual:#04x}, expected {want:#04x}; frame was {raw.hex()}"
+            )
+
+        # A non-zero scramble key means legacy XOR obfuscation. Refusing loudly
+        # beats decrypting it as AES into plausible-looking garbage.
+        if scramble_key := raw[10]:
+            raise UnsupportedProtocol(
+                f"Lock is using legacy XOR scrambling (key {scramble_key:#04x}); only AES locks are supported"
+            )
+
+        payload = body[HEADER_LENGTH:]
+        return cls(
+            version=LockVersion(
+                protocol_type=raw[2],
+                protocol_version=raw[3],
+                scene=raw[4],
+                group_id=int.from_bytes(raw[5:7], "big"),
+                org_id=int.from_bytes(raw[7:9], "big"),
+            ),
+            command=raw[9],
+            data=decrypt(aes_key, payload)
+            if aes_key is not None and payload
+            else payload,
+            scramble_key=scramble_key,
+        )
+
+
+def _checksummed(body: bytes) -> bytes:
+    """Return the span of a frame the CRC-8 covers: header and payload.
+
+    Pulled out so `encode` and `decode` cannot drift apart on the span and
+    still agree with each other.
+    """
+    return body
+
+
+class FrameAssembler:
+    """Reassembles GATT notifications into whole frames.
+
+    A frame is up to 270 bytes but a BLE notification carries around 20, so
+    responses arrive in pieces and a single notification can carry the tail of
+    one frame and the head of the next. This holds the leftovers between
+    callbacks.
+
+    It resynchronises rather than failing: bytes before a `MAGIC` are dropped,
+    so starting mid-frame costs one frame, not the session. Stateful by
+    nature, so one instance belongs to one connection.
+    """
+
+    def __init__(self) -> None:
+        """Start with an empty buffer."""
+        self._buffer = bytearray()
+
+    def reset(self) -> None:
+        """Discard any partial frame. Call on connect and on disconnect."""
+        self._buffer.clear()
+
+    def feed(self, chunk: bytes) -> list[bytes]:
+        """Add received bytes, returning whichever frames are now complete.
+
+        Returns the raw bytes of each frame, still to be passed to
+        `Frame.decode` - keeping "where does a frame end" separate from "is
+        this frame valid" means a corrupt frame raises without desynchronising
+        the stream behind it.
+        """
+        self._buffer.extend(chunk)
+        frames: list[bytes] = []
+
+        while True:
+            start = self._buffer.find(MAGIC)
+            if start == -1:
+                # No frame start in sight. Keep the last byte: it could be the
+                # 0x7f of a magic split across two notifications.
+                del self._buffer[: max(0, len(self._buffer) - 1)]
+                break
+
+            del self._buffer[:start]
+
+            if len(self._buffer) < HEADER_LENGTH:
+                break
+
+            total = HEADER_LENGTH + self._buffer[11] + TRAILER_LENGTH
+            if len(self._buffer) < total:
+                break
+
+            frames.append(bytes(self._buffer[:total]))
+            del self._buffer[:total]
+
+        # No size cap needed: every path out bounds the buffer, and the
+        # one-byte length field caps a declared frame at MAX_FRAME_LENGTH.
+        return frames
+
+
+# The reply envelope: which command is being answered, then whether it worked.
+RESPONSE_COMMAND = 0
+RESPONSE_STATUS = 1
+RESPONSE_HEADER_LENGTH = 2
+RESPONSE_SUCCESS = 0x01
+
+
+@dataclass(frozen=True)
+class Response:
+    """The envelope every `RESPONSE` frame's payload carries.
+
+    An encrypted `QUERY_LOCK_STATUS` comes back as `14 01 64 00 01`: the
+    opcode just sent, then `0x01` for success, then command-specific data. So
+    a reply says what it answers and whether it worked before any payload.
+
+    `command` is a plain int for the same reason `Frame.command` is.
+    """
+
+    command: int | None
+    succeeded: bool | None
+    data: bytes
+
+    @classmethod
+    def parse(cls, payload: bytes) -> Response:
+        """Split a reply payload, tolerating one shorter than the envelope.
+
+        Never raises. A truncated reply reports `None` for what it did not
+        contain.
+        """
+        return cls(
+            command=payload[RESPONSE_COMMAND]
+            if len(payload) > RESPONSE_COMMAND
+            else None,
+            succeeded=(
+                payload[RESPONSE_STATUS] == RESPONSE_SUCCESS
+                if len(payload) > RESPONSE_STATUS
+                else None
+            ),
+            data=payload[RESPONSE_HEADER_LENGTH:],
+        )
+
+
+# `locked`/`door_open` follow models.SensorState (opened = 0, closed = 1),
+# which the cloud path already assumes. The standalone door-sensor product
+# documents the opposite mapping, but that is a separate accessory.
+_LOCKED_STATES = {0: True, 1: False}
+_DOOR_STATES = {0: True, 1: False}
+
+
+@dataclass(frozen=True)
+class LockStatus:
+    """What a lock reports about itself, read locally and unauthenticated.
+
+    The three bytes after the envelope, cross-checked against the cloud for
+    the same lock at the same moment: `64 00 01` against `electricQuantity:
+    100`, `state: 0` and `sensorState: 1`. `QUERY_LOCK_STATUS` is answered
+    without a session, so the local state read needs none of the
+    authentication built for changing state.
+
+    `door_open` is `None` on a lock that does not report a door; callers must
+    gate on the value being present rather than assuming a default.
+    """
+
+    battery: int | None
+    locked: bool | None
+    door_open: bool | None
+
+    @classmethod
+    def parse(cls, payload: bytes) -> LockStatus:
+        """Read a `QUERY_LOCK_STATUS` reply. Never raises; missing is `None`."""
+        data = Response.parse(payload).data
+        return cls(
+            battery=data[0] if len(data) > 0 else None,
+            locked=_LOCKED_STATES.get(data[1]) if len(data) > 1 else None,
+            door_open=_DOOR_STATES.get(data[2]) if len(data) > 2 else None,
+        )
+
+
+@dataclass(frozen=True)
+class DeviceFeatures:
+    """What a lock says about itself when asked with no credentials at all.
+
+    `SEARCH_DEVICE_FEATURE`'s reply, decoded off a KT170 against values the
+    cloud reported for the same lock:
+
+    ```
+    01                        opcode echoed
+    01                        success
+    64                        battery = 100
+    35 CC F5 F7               special_value
+    80 0C 2D 44               feature bits
+    00 00 00 00 00 00 00 00   still unidentified, zero on this lock
+    ```
+
+    The cloud reports `featureValue: "800C2D4435CCF5F7"` and `specialValue:
+    902624759` (= `0x35CCF5F7`), so `featureValue` is the feature bits and
+    `specialValue` concatenated, and the lock sends the same eight bytes with
+    the halves swapped - see `feature_value_bytes`. `extra` is the trailing
+    bytes nothing has identified yet, kept raw.
+    """
+
+    battery: int | None
+    feature_value: int | None
+    special_value: int | None
+    extra: bytes
+
+    @classmethod
+    def parse(cls, payload: bytes) -> DeviceFeatures:
+        """Read a `SEARCH_DEVICE_FEATURE` reply. Never raises; missing is `None`."""
+        data = Response.parse(payload).data
+        return cls(
+            battery=data[0] if len(data) > 0 else None,
+            special_value=int.from_bytes(data[1:5], "big") if len(data) >= 5 else None,
+            feature_value=int.from_bytes(data[5:9], "big") if len(data) >= 9 else None,
+            extra=data[9:],
+        )
+
+
+def feature_value_bytes(feature_value: str) -> bytes:
+    """The cloud's `featureValue` in the byte order the lock actually sends.
+
+    The two 32-bit halves swap - see `DeviceFeatures`. Anything comparing a
+    cloud `featureValue` against bytes off the radio has to go through here.
+    Returns empty for anything that is not the expected 16 hex digits, turning
+    a comparison off rather than failing it.
+    """
+    try:
+        raw = bytes.fromhex(feature_value)
+    except ValueError:
+        return b""
+    if len(raw) != 8:
+        return b""
+    return raw[4:] + raw[:4]

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -29,7 +29,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from .api import TTLockApi
-from .ble import BleData, async_bluetooth_available, async_track_address
+from .ble import (
+    BleData,
+    BleError,
+    async_bluetooth_available,
+    async_read_status,
+    async_track_address,
+)
+from .ble_protocol import LockStatus, LockVersion, ProtocolError, parse_aes_key
 from .capture import LockTrafficCapture
 from .const import (
     CONF_POLL_INTERVAL,
@@ -240,6 +247,12 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         # advertisement (or immediately, if the stack already has one)
         self.ble: BleData = BleData()
 
+        # What lock/detail told us about talking to the lock directly. Kept
+        # as received; parsed on use so an odd value costs a local read, not
+        # the poll.
+        self._ble_version: dict[str, int] | None = None
+        self._ble_key: str | None = None
+
         # Whether we've already made this restart's one-shot door-sensor
         # recheck (see _check_for_sensor) - deliberately in-memory, not
         # persisted, so it naturally resets to False on every restart.
@@ -299,6 +312,36 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         self.ble = ble
         self.async_update_listeners()
 
+    def _ble_credentials(self) -> tuple[LockVersion, bytes] | None:
+        """The protocol dialect and AES key, or None if lock/detail's aren't usable."""
+        if self._ble_version is None or self._ble_key is None:
+            return None
+        with suppress(ValueError):
+            return LockVersion.from_cloud(self._ble_version), parse_aes_key(
+                self._ble_key
+            )
+        return None
+
+    async def async_read_state_ble(self) -> LockStatus | None:
+        """Read lock state over Bluetooth, or None if that isn't possible right now.
+
+        Never raises - the caller has the cloud to fall back on, and a lock that
+        is out of range or not answering is expected, not exceptional.
+        """
+        if not async_bluetooth_available(self.hass) or not self.ble.in_range:
+            return None
+        credentials = self._ble_credentials()
+        if credentials is None:
+            return None
+        version, aes_key = credentials
+        try:
+            return await async_read_status(
+                self.hass, self.data.mac, self.data.name, version, aes_key
+            )
+        except (BleError, ProtocolError) as err:
+            _LOGGER.debug("Local state read for lock %s failed: %s", self.lock_id, err)
+            return None
+
     async def _async_update_data(self) -> LockState:
         if not self.connectable:
             raise UpdateFailed(
@@ -325,6 +368,8 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
                 new_data.firmware_version = details.firmwareRevision
                 new_data.auto_lock_seconds = details.autoLockTime
                 new_data.lock_sound = bool(details.lockSound)
+                self._ble_version = details.lockVersion
+                self._ble_key = details.aesKeyStr
                 self._details_last_fetched = now
 
             if Features.door_sensor in new_data.features:
@@ -341,22 +386,34 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
 
             # Fast tier: re-verify lock (and door) state every poll - this is
             # the real-time-relevant signal and the reason the poll exists.
-            try:
-                state = await self.api.get_lock_state(self.lock_id)
-                new_data.locked = state.locked == State.locked
-                if sensor_present(new_data.sensor):
-                    new_data.sensor.opened = state.opened == SensorState.opened
-            except Exception as err:
-                if new_data.locked is None:
-                    # first-ever fetch: tolerate failure, entity shows "unknown"
-                    _LOGGER.debug("Failed to fetch initial lock state", exc_info=True)
-                else:
-                    # we previously had a verified state - a failure to re-verify now
-                    # means we can no longer trust it (e.g. gateway/webhooks silently
-                    # died), so surface it via the standard unavailable path
-                    raise UpdateFailed(
-                        f"Failed to re-verify lock state for {self.lock_id}"
-                    ) from err
+            # A lock in Bluetooth range answers the same question locally,
+            # without spending cloud quota; the cloud remains the fallback.
+            status = await self.async_read_state_ble()
+            if status is not None and status.locked is not None:
+                new_data.locked = status.locked
+                if status.battery is not None:
+                    new_data.battery_level = status.battery
+                if sensor_present(new_data.sensor) and status.door_open is not None:
+                    new_data.sensor.opened = status.door_open
+            else:
+                try:
+                    state = await self.api.get_lock_state(self.lock_id)
+                    new_data.locked = state.locked == State.locked
+                    if sensor_present(new_data.sensor):
+                        new_data.sensor.opened = state.opened == SensorState.opened
+                except Exception as err:
+                    if new_data.locked is None:
+                        # first-ever fetch: tolerate failure, entity shows "unknown"
+                        _LOGGER.debug(
+                            "Failed to fetch initial lock state", exc_info=True
+                        )
+                    else:
+                        # we previously had a verified state - a failure to re-verify now
+                        # means we can no longer trust it (e.g. gateway/webhooks silently
+                        # died), so surface it via the standard unavailable path
+                        raise UpdateFailed(
+                            f"Failed to re-verify lock state for {self.lock_id}"
+                        ) from err
 
             # Slow tier: passage-mode schedule config, rarely changes.
             if self._slow_tier_due(self._passage_last_fetched, now):

--- a/custom_components/ttlock/manifest.json
+++ b/custom_components/ttlock/manifest.json
@@ -12,7 +12,7 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jbergler/hass-ttlock/issues",
-  "requirements": ["pydantic"],
+  "requirements": ["pydantic", "bleak-retry-connector>=4.4.0"],
   "ssdp": [],
   "version": "v0.0.0",
   "zeroconf": []

--- a/custom_components/ttlock/models.py
+++ b/custom_components/ttlock/models.py
@@ -97,9 +97,13 @@ class Lock(LockMacModel):
     passageMode: OnOff = OnOff.unknown
     passageModeAutoUnlock: OnOff = OnOff.unknown
     date: int
+    # Protocol dialect every BLE frame echoes back, see ble_protocol.LockVersion.
+    lockVersion: dict[str, int] | None = None
 
     # sensitive fields
     noKeyPwd: str = Field(alias="adminPwd")
+    # Per-lock AES key BLE frames are encrypted with. Undocumented, redacted.
+    aesKeyStr: str | None = None
 
 
 class LockSummary(LockMacModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Global fixtures for ttlock integration."""
 
+import asyncio
 from collections.abc import Callable
 import sys
 from time import time
@@ -22,6 +23,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ttlock.api import TTLockApi
+from custom_components.ttlock.ble_protocol import FrameAssembler
 from custom_components.ttlock.capture import LockTrafficCapture
 from custom_components.ttlock.const import DOMAIN, TT_LOCKS
 from custom_components.ttlock.coordinator import LockUpdateCoordinator
@@ -348,6 +350,10 @@ class BluetoothRecorder:
         self.seed: BluetoothServiceInfoBleak | None = None
         self.seed_address: str | None = None
         self.unsubscribed: list[str] = []
+        # What async_ble_device_from_address hands back, and what it was asked for.
+        self.device: BLEDevice | None = None
+        self.device_address: str | None = None
+        self.device_connectable: bool | None = None
 
 
 @pytest.fixture
@@ -411,10 +417,16 @@ def mock_bluetooth(
         recorder.seed_address = address
         return recorder.seed
 
+    def ble_device_from_address(hass, address, connectable=True):
+        recorder.device_address = address
+        recorder.device_connectable = connectable
+        return recorder.device
+
     stub = types.ModuleType("homeassistant.components.bluetooth")
     stub.async_register_callback = register_callback  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
     stub.async_track_unavailable = track_unavailable  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
     stub.async_last_service_info = last_service_info  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
+    stub.async_ble_device_from_address = ble_device_from_address  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
     stub.BluetoothScanningMode = BluetoothScanningMode  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
     stub.MONOTONIC_TIME = monotonic_time_coarse  # ty: ignore[unresolved-attribute] - types.ModuleType has no declared attrs, this is a test stub
 
@@ -422,4 +434,86 @@ def mock_bluetooth(
     monkeypatch.setattr(ha_components, "bluetooth", stub, raising=False)
     hass.config.components.add("bluetooth")
 
+    return recorder
+
+
+class GattRecorder:
+    """A connected BleakClient as ble.py sees it, recording every call.
+
+    `responder` plays the lock: it gets each complete inbound frame and
+    returns the chunks to notify back, delivered synchronously from within
+    write_gatt_char the way a real notification would race the write.
+    """
+
+    def __init__(self) -> None:
+        self.connect_error: Exception | None = None
+        self.connect_delay: float = 0.0
+        self.connects = 0
+        self.connected_name: str | None = None
+        self.max_attempts: int | None = None
+        self.disconnect_error: Exception | None = None
+        self.disconnects = 0
+        self.notify_error: Exception | None = None
+        self.notify_uuid: str | None = None
+        self.notify_handler: Callable | None = None
+        self.notify_stops: list[str] = []
+        self.write_error: Exception | None = None
+        self.writes: list[bytes] = []
+        self.written_uuids: list[str] = []
+        self.received: list[bytes] = []
+        self.responder: Callable[[bytes], list[bytes]] | None = None
+        self.mtu_size: int | None = 23
+        self._inbound = FrameAssembler()
+
+    async def start_notify(self, uuid: str, handler: Callable) -> None:
+        if self.notify_error is not None:
+            raise self.notify_error
+        self.notify_uuid = uuid
+        self.notify_handler = handler
+
+    async def stop_notify(self, uuid: str) -> None:
+        self.notify_stops.append(uuid)
+        if self.notify_error is not None:
+            raise self.notify_error
+
+    async def write_gatt_char(
+        self, uuid: str, data: bytes, response: bool = True
+    ) -> None:
+        if self.write_error is not None:
+            raise self.write_error
+        self.writes.append(bytes(data))
+        self.written_uuids.append(uuid)
+        for raw in self._inbound.feed(bytes(data)):
+            self.received.append(raw)
+            if self.responder is not None and self.notify_handler is not None:
+                for chunk in self.responder(raw):
+                    self.notify_handler(None, bytearray(chunk))
+
+    async def disconnect(self) -> None:
+        self.disconnects += 1
+        if self.disconnect_error is not None:
+            raise self.disconnect_error
+
+
+@pytest.fixture
+def mock_gatt(
+    monkeypatch: pytest.MonkeyPatch, mock_bluetooth: BluetoothRecorder
+) -> GattRecorder:
+    """Put the lock in connectable range and answer every connection with a GattRecorder."""
+    recorder = GattRecorder()
+    mock_bluetooth.device = BLEDevice(MOCK_LOCK_MAC, MOCK_LOCK_NAME, {})
+
+    async def establish_connection(client_class, device, name, **kwargs):
+        recorder.connects += 1
+        recorder.connected_name = name
+        recorder.max_attempts = kwargs.get("max_attempts")
+        if recorder.connect_delay:
+            await asyncio.sleep(recorder.connect_delay)
+        if recorder.connect_error is not None:
+            raise recorder.connect_error
+        return recorder
+
+    monkeypatch.setattr(
+        "bleak_retry_connector.establish_connection", establish_connection
+    )
     return recorder

--- a/tests/const.py
+++ b/tests/const.py
@@ -53,6 +53,11 @@ BASIC_LOCK_DETAILS = {
     },
     "sensitivity": -1,
 }
+
+# The lockVersion object lock/detail returns, identifying the protocol dialect
+# every BLE frame must echo back. Matches BASIC_LOCK_DETAILS above.
+MOCK_LOCK_VERSION = BASIC_LOCK_DETAILS["lockVersion"]
+
 LOCK_DETAILS_WITH_SENSOR = {
     **BASIC_LOCK_DETAILS,
     "featureValue": "F44354CF5F3",

--- a/tests/const.py
+++ b/tests/const.py
@@ -10,6 +10,10 @@ MOCK_LOCK_NAME = "S31_c401cc"
 # it.
 TTLOCK_SERVICE_UUID = "00001910-0000-1000-8000-00805f9b34fb"
 
+# aesKeyStr as lock/detail returns it. Comma-delimited hex, the one encoding
+# that is ambiguous with a Java signed-byte listing.
+MOCK_LOCK_AES_KEY = "0f,1e,2d,3c,4b,5a,69,78,87,96,a5,b4,c3,d2,e1,f0"
+
 BASIC_LOCK_DETAILS = {
     "date": 1669690212000,
     "lockAlias": "Front Door",
@@ -41,7 +45,7 @@ BASIC_LOCK_DETAILS = {
     "lockFlagPos": 0,
     "lockUpdateDate": 1682201024000,
     "keyboardPwdVersion": 4,
-    "aesKeyStr": "<REMOVED>",
+    "aesKeyStr": MOCK_LOCK_AES_KEY,
     "hardwareRevision": "1.6",
     "openDirection": 0,
     "lockVersion": {

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -1,4 +1,4 @@
-"""Tests for local Bluetooth presence tracking.
+"""Tests for local Bluetooth presence tracking and state reads.
 
 conftest's mock_bluetooth stands in for HA's bluetooth component - see its
 docstring for why the real one can't be loaded here. Stubbing at exactly the
@@ -7,26 +7,120 @@ the things that are easy to get silently wrong: that a lock heard before we
 loaded is picked up without waiting for its next advertisement, that going
 out of range clears the reading rather than freezing it, and that
 unsubscribing releases both registrations.
+
+mock_gatt does the same for the connection: it answers establish_connection
+with a recorder that plays the lock's side of the GATT conversation.
 """
 
+from dataclasses import dataclass, field
 from datetime import timedelta
 
+from bleak_retry_connector import BleakError
 from habluetooth import BluetoothScanningMode
 import pytest
 
+from custom_components.ttlock import ble
+from custom_components.ttlock.api import RequestFailed
 from custom_components.ttlock.ble import (
+    BleConnectionError,
     BleData,
+    BleError,
+    BleNoResponse,
+    BleNotInRange,
     async_bluetooth_available,
+    async_command_session,
+    async_read_status,
     async_track_address,
 )
+from custom_components.ttlock.ble_protocol import (
+    NOTIFY_UUID,
+    WRITE_UUID,
+    ChecksumError,
+    Command,
+    Frame,
+    LockVersion,
+    parse_aes_key,
+)
+from custom_components.ttlock.models import Lock
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .const import MOCK_LOCK_MAC as LOCK_MAC
+from .conftest import GattRecorder
+from .const import (
+    BASIC_LOCK_DETAILS,
+    MOCK_LOCK_AES_KEY,
+    MOCK_LOCK_MAC as LOCK_MAC,
+    MOCK_LOCK_VERSION,
+)
 
 # BluetoothChange has exactly one member and ble.py ignores the argument
 # entirely; this stands in for it.
 ADVERTISEMENT = "advertisement"
+
+LOCK_NAME = "Front Door"
+
+# A KT170's answer to QUERY_LOCK_STATUS: the echoed opcode, success, then
+# battery 100%, locked, door closed.
+STATUS_LOCKED = b"\x14\x01\x64\x00\x01"
+STATUS_UNLOCKED_DOOR_OPEN = b"\x14\x01\x64\x01\x00"
+
+
+@pytest.fixture
+def lock_version() -> LockVersion:
+    return LockVersion.from_cloud(MOCK_LOCK_VERSION)
+
+
+@pytest.fixture
+def aes_key() -> bytes:
+    return parse_aes_key(MOCK_LOCK_AES_KEY)
+
+
+@dataclass
+class SpeakingLock:
+    """A GattRecorder that answers commands the way a lock would.
+
+    `answer` scripts the reply for one opcode (or every opcode, with
+    `to=None`); what the lock was asked lands in `asked`.
+    """
+
+    gatt: GattRecorder
+    version: LockVersion
+    asked: list[Frame] = field(default_factory=list)
+    _replies: dict[int | None, tuple[int, bytes, bytes | None, int]] = field(
+        default_factory=dict
+    )
+
+    def answer(
+        self,
+        command: int = Command.RESPONSE,
+        data: bytes = b"",
+        key: bytes | None = None,
+        chunk: int = 20,
+        *,
+        to: int | None = None,
+    ) -> None:
+        self._replies[to] = (command, data, key, chunk)
+
+    def stay_silent(self) -> None:
+        self._replies.clear()
+
+    def respond(self, raw: bytes) -> list[bytes]:
+        frame = Frame.decode(raw)
+        self.asked.append(frame)
+        reply = self._replies.get(frame.command, self._replies.get(None))
+        if reply is None:
+            return []
+        command, data, key, chunk = reply
+        wire = Frame(self.version, command, data).encode(aes_key=key)
+        return [wire[i : i + chunk] for i in range(0, len(wire), chunk)]
+
+
+@pytest.fixture
+def speaking_lock(mock_gatt: GattRecorder, lock_version: LockVersion) -> SpeakingLock:
+    lock = SpeakingLock(mock_gatt, lock_version)
+    lock.answer()
+    mock_gatt.responder = lock.respond
+    return lock
 
 
 class TestBleData:
@@ -225,3 +319,422 @@ class TestCoordinatorBleTracking:
         )
 
         assert coordinator.data is before
+
+
+class TestAsyncCommandSession:
+    """Connecting and, above all, always disconnecting."""
+
+    async def test_asks_for_a_connectable_route(
+        self, hass, mock_bluetooth, speaking_lock, lock_version
+    ):
+        async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+            pass
+
+        assert mock_bluetooth.device_address == LOCK_MAC
+        assert mock_bluetooth.device_connectable is True
+        assert speaking_lock.gatt.connected_name == LOCK_NAME
+        assert speaking_lock.gatt.max_attempts == ble.CONNECT_ATTEMPTS
+
+    async def test_no_route_is_not_in_range(
+        self, hass, mock_bluetooth, mock_gatt, lock_version
+    ):
+        mock_bluetooth.device = None
+
+        with pytest.raises(BleNotInRange, match=LOCK_NAME):
+            async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+                pass
+
+        assert mock_gatt.connects == 0
+
+    async def test_disconnects_on_exit(
+        self, hass, mock_bluetooth, speaking_lock, lock_version
+    ):
+        async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+            assert speaking_lock.gatt.disconnects == 0
+
+        assert speaking_lock.gatt.disconnects == 1
+
+    async def test_disconnects_when_the_body_raises(
+        self, hass, mock_bluetooth, speaking_lock, lock_version
+    ):
+        with pytest.raises(RuntimeError, match="body"):
+            async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+                raise RuntimeError("body")
+
+        assert speaking_lock.gatt.disconnects == 1
+
+    async def test_a_failed_disconnect_does_not_mask_the_body(
+        self, hass, mock_bluetooth, speaking_lock, lock_version
+    ):
+        speaking_lock.gatt.disconnect_error = BleakError("gone")
+
+        with pytest.raises(RuntimeError, match="body"):
+            async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+                raise RuntimeError("body")
+
+    async def test_a_failed_disconnect_alone_is_fine(
+        self, hass, mock_bluetooth, speaking_lock, lock_version
+    ):
+        speaking_lock.gatt.disconnect_error = BleakError("gone")
+
+        async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+            pass
+
+    async def test_a_refused_connection_names_the_lock(
+        self, hass, mock_bluetooth, mock_gatt, lock_version
+    ):
+        mock_gatt.connect_error = BleakError("refused")
+
+        with pytest.raises(BleConnectionError, match=f"{LOCK_NAME}.*refused"):
+            async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+                pass
+
+    async def test_gives_up_rather_than_hanging(
+        self, hass, mock_bluetooth, mock_gatt, lock_version, monkeypatch
+    ):
+        monkeypatch.setattr(ble, "CONNECT_TIMEOUT", 0.01)
+        mock_gatt.connect_delay = 5
+
+        with pytest.raises(BleConnectionError, match="Timed out"):
+            async with async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version):
+                pass
+
+
+class TestLockSession:
+    """One command, one reply, over a subscribed connection."""
+
+    @pytest.fixture
+    def session(self, hass, mock_bluetooth, speaking_lock, lock_version):
+        return async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version)
+
+    async def test_subscribes_before_writing_and_unsubscribes_after(
+        self, session, speaking_lock
+    ):
+        async with session as lock:
+            assert speaking_lock.gatt.notify_uuid == NOTIFY_UUID
+            assert speaking_lock.gatt.notify_stops == []
+            await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+
+        assert speaking_lock.gatt.notify_stops == [NOTIFY_UUID]
+
+    async def test_writes_to_the_command_characteristic(self, session, speaking_lock):
+        async with session as lock:
+            await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+
+        assert set(speaking_lock.gatt.written_uuids) == {WRITE_UUID}
+
+    async def test_the_lock_receives_the_command(self, session, speaking_lock):
+        async with session as lock:
+            await lock.execute(Command.SEARCH_DEVICE_FEATURE, b"\x01", encrypted=False)
+
+        (asked,) = speaking_lock.asked
+        assert asked.command == Command.SEARCH_DEVICE_FEATURE
+        assert asked.data == b"\x01"
+
+    async def test_returns_the_reply(self, session, speaking_lock):
+        speaking_lock.answer(Command.RESPONSE, b"\x01\x01\x02")
+
+        async with session as lock:
+            reply = await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+
+        assert reply.command == Command.RESPONSE
+        assert reply.data == b"\x01\x01\x02"
+
+    async def test_reassembles_a_reply_split_across_notifications(
+        self, session, speaking_lock
+    ):
+        speaking_lock.answer(Command.RESPONSE, bytes(range(40)), chunk=7)
+
+        async with session as lock:
+            reply = await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+
+        assert reply.data == bytes(range(40))
+
+    async def test_splits_a_long_command_to_the_mtu(self, session, speaking_lock):
+        async with session as lock:
+            await lock.execute(
+                Command.SEARCH_DEVICE_FEATURE, bytes(60), encrypted=False
+            )
+
+        assert len(speaking_lock.gatt.writes) > 1
+        assert all(len(write) <= 20 for write in speaking_lock.gatt.writes)
+
+    async def test_uses_a_larger_negotiated_mtu(self, session, speaking_lock):
+        speaking_lock.gatt.mtu_size = 247
+
+        async with session as lock:
+            await lock.execute(
+                Command.SEARCH_DEVICE_FEATURE, bytes(60), encrypted=False
+            )
+
+        assert len(speaking_lock.gatt.writes) == 1
+
+    async def test_an_unknown_mtu_means_the_default(self, session, speaking_lock):
+        speaking_lock.gatt.mtu_size = None
+
+        async with session as lock:
+            await lock.execute(
+                Command.SEARCH_DEVICE_FEATURE, bytes(60), encrypted=False
+            )
+
+        assert all(len(write) <= 20 for write in speaking_lock.gatt.writes)
+
+    async def test_silence_is_no_response(self, session, speaking_lock, monkeypatch):
+        monkeypatch.setattr(ble, "RESPONSE_TIMEOUT", 0.01)
+        speaking_lock.stay_silent()
+
+        async with session as lock:
+            with pytest.raises(BleNoResponse, match=LOCK_NAME) as raised:
+                await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+
+        assert not isinstance(raised.value, BleConnectionError)
+
+    async def test_a_corrupt_reply_raises(self, session, speaking_lock, lock_version):
+        wire = bytearray(Frame(lock_version, Command.RESPONSE, b"\x01\x01").encode())
+        wire[12] ^= 0xFF
+        speaking_lock.gatt.responder = lambda raw: [bytes(wire)]
+
+        async with session as lock:
+            with pytest.raises(ChecksumError):
+                await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+
+    async def test_a_failed_write_is_a_connection_error(self, session, speaking_lock):
+        speaking_lock.gatt.write_error = BleakError("dropped")
+
+        async with session as lock:
+            with pytest.raises(BleConnectionError, match="dropped"):
+                await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+
+    async def test_a_refused_subscription_is_a_connection_error(
+        self, session, speaking_lock
+    ):
+        speaking_lock.gatt.notify_error = BleakError("no notify")
+
+        with pytest.raises(BleConnectionError, match="subscribe"):
+            async with session:
+                pass
+
+        assert speaking_lock.gatt.disconnects == 1
+
+    async def test_unsubscribes_when_the_body_raises(self, session, speaking_lock):
+        with pytest.raises(RuntimeError):
+            async with session:
+                raise RuntimeError("body")
+
+        assert speaking_lock.gatt.notify_stops == [NOTIFY_UUID]
+
+    async def test_a_failed_unsubscribe_is_fine(self, session, speaking_lock):
+        async with session as lock:
+            await lock.execute(Command.SEARCH_DEVICE_FEATURE, encrypted=False)
+            speaking_lock.gatt.notify_error = BleakError("gone")
+
+
+class TestLockSessionEncryption:
+    @pytest.fixture
+    def session(self, hass, mock_bluetooth, speaking_lock, lock_version, aes_key):
+        return async_command_session(hass, LOCK_MAC, LOCK_NAME, lock_version, aes_key)
+
+    async def test_the_payload_is_encrypted_on_the_wire(
+        self, session, speaking_lock, aes_key
+    ):
+        async with session as lock:
+            await lock.execute(Command.QUERY_LOCK_STATUS, b"hello")
+
+        (raw,) = speaking_lock.gatt.received
+        assert Frame.decode(raw).data != b"hello"
+        assert Frame.decode(raw, aes_key=aes_key).data == b"hello"
+
+    async def test_an_encrypted_reply_is_decrypted(
+        self, session, speaking_lock, aes_key
+    ):
+        speaking_lock.answer(Command.RESPONSE, STATUS_LOCKED, key=aes_key)
+
+        async with session as lock:
+            reply = await lock.execute(Command.QUERY_LOCK_STATUS)
+
+        assert reply.data == STATUS_LOCKED
+
+    async def test_a_cleartext_command_stays_cleartext(self, session, speaking_lock):
+        async with session as lock:
+            await lock.execute(Command.SEARCH_DEVICE_FEATURE, b"\x01", encrypted=False)
+
+        (raw,) = speaking_lock.gatt.received
+        assert Frame.decode(raw).data == b"\x01"
+
+    async def test_no_key_refuses_to_send(
+        self, hass, mock_bluetooth, speaking_lock, lock_version
+    ):
+        async with async_command_session(
+            hass, LOCK_MAC, LOCK_NAME, lock_version
+        ) as lock:
+            with pytest.raises(BleError, match="no AES key"):
+                await lock.execute(Command.QUERY_LOCK_STATUS)
+
+        assert speaking_lock.gatt.writes == []
+
+
+class TestAsyncReadStatus:
+    @pytest.fixture(autouse=True)
+    def locked(self, speaking_lock, aes_key):
+        speaking_lock.answer(Command.RESPONSE, STATUS_LOCKED, key=aes_key)
+
+    async def test_reads_battery_lock_and_door(
+        self, hass, mock_bluetooth, lock_version, aes_key
+    ):
+        status = await async_read_status(
+            hass, LOCK_MAC, LOCK_NAME, lock_version, aes_key
+        )
+
+        assert (status.battery, status.locked, status.door_open) == (100, True, False)
+
+    async def test_asks_with_an_encrypted_query(
+        self, hass, mock_bluetooth, speaking_lock, lock_version, aes_key
+    ):
+        await async_read_status(hass, LOCK_MAC, LOCK_NAME, lock_version, aes_key)
+
+        (asked,) = speaking_lock.asked
+        assert asked.command == Command.QUERY_LOCK_STATUS
+        (raw,) = speaking_lock.gatt.received
+        assert Frame.decode(raw, aes_key=aes_key).data == b""
+
+    async def test_closes_the_connection(
+        self, hass, mock_bluetooth, speaking_lock, lock_version, aes_key
+    ):
+        await async_read_status(hass, LOCK_MAC, LOCK_NAME, lock_version, aes_key)
+
+        assert speaking_lock.gatt.notify_stops == [NOTIFY_UUID]
+        assert speaking_lock.gatt.disconnects == 1
+
+    async def test_a_short_reply_reads_as_unknown(
+        self, hass, mock_bluetooth, speaking_lock, lock_version, aes_key
+    ):
+        speaking_lock.answer(Command.RESPONSE, b"\x14\x01", key=aes_key)
+
+        status = await async_read_status(
+            hass, LOCK_MAC, LOCK_NAME, lock_version, aes_key
+        )
+
+        assert (status.battery, status.locked, status.door_open) == (None, None, None)
+
+
+class TestCoordinatorBleRead:
+    """The poll's fast tier: local when it can be, cloud otherwise.
+
+    The default cloud scenario reports the lock unlocked; the speaking lock
+    reports it locked, so which one answered is visible in the result.
+    """
+
+    @pytest.fixture
+    def in_range(self, coordinator, mock_bluetooth):
+        coordinator.ble = BleData(rssi=-60)
+
+    @pytest.fixture
+    def cloud_unreachable(self, monkeypatch):
+        async def get_lock_state(self, lock_id):
+            raise RequestFailed("no gateway")
+
+        monkeypatch.setattr(
+            "custom_components.ttlock.api.TTLockApi.get_lock_state", get_lock_state
+        )
+
+    @pytest.fixture
+    def locked_locally(self, speaking_lock, aes_key):
+        speaking_lock.answer(Command.RESPONSE, STATUS_LOCKED, key=aes_key)
+        return speaking_lock
+
+    async def test_without_bluetooth_the_cloud_answers(
+        self, coordinator, mock_api_responses
+    ):
+        mock_api_responses("default")
+
+        await coordinator.async_refresh()
+
+        assert coordinator.data.locked is False
+
+    async def test_in_range_the_lock_answers(
+        self,
+        coordinator,
+        mock_api_responses,
+        in_range,
+        locked_locally,
+        cloud_unreachable,
+    ):
+        mock_api_responses("default")
+
+        await coordinator.async_refresh()
+
+        assert coordinator.last_update_success
+        assert coordinator.data.locked is True
+        assert coordinator.data.battery_level == 100
+        assert locked_locally.gatt.connects == 1
+
+    async def test_out_of_range_the_cloud_answers(
+        self, coordinator, mock_api_responses, mock_bluetooth, locked_locally
+    ):
+        mock_api_responses("default")
+
+        await coordinator.async_refresh()
+
+        assert coordinator.data.locked is False
+        assert locked_locally.gatt.connects == 0
+
+    async def test_an_unreadable_key_means_the_cloud(
+        self, coordinator, mock_api_responses, in_range, locked_locally, monkeypatch
+    ):
+        mock_api_responses("default")
+
+        async def get_lock(self, lock_id):
+            return Lock.model_validate({**BASIC_LOCK_DETAILS, "aesKeyStr": "<REMOVED>"})
+
+        monkeypatch.setattr("custom_components.ttlock.api.TTLockApi.get_lock", get_lock)
+
+        await coordinator.async_refresh()
+
+        assert coordinator.data.locked is False
+        assert locked_locally.gatt.connects == 0
+
+    async def test_a_failed_local_read_falls_back_to_the_cloud(
+        self, coordinator, mock_api_responses, in_range, locked_locally
+    ):
+        mock_api_responses("default")
+        locked_locally.gatt.connect_error = BleakError("refused")
+
+        await coordinator.async_refresh()
+
+        assert coordinator.last_update_success
+        assert coordinator.data.locked is False
+
+    async def test_a_silent_lock_falls_back_to_the_cloud(
+        self, coordinator, mock_api_responses, in_range, locked_locally, monkeypatch
+    ):
+        mock_api_responses("default")
+        monkeypatch.setattr(ble, "RESPONSE_TIMEOUT", 0.01)
+        locked_locally.stay_silent()
+
+        await coordinator.async_refresh()
+
+        assert coordinator.last_update_success
+        assert coordinator.data.locked is False
+
+    async def test_door_state_reaches_a_present_sensor(
+        self, coordinator, mock_api_responses, in_range, locked_locally, aes_key
+    ):
+        mock_api_responses("with_sensor")
+        locked_locally.answer(Command.RESPONSE, STATUS_UNLOCKED_DOOR_OPEN, key=aes_key)
+
+        await coordinator.async_refresh()
+
+        assert coordinator.data.locked is False
+        assert coordinator.data.sensor is not None
+        assert coordinator.data.sensor.opened is True
+
+    async def test_door_state_is_ignored_without_a_sensor(
+        self, coordinator, mock_api_responses, in_range, locked_locally, aes_key
+    ):
+        mock_api_responses("default")
+        locked_locally.answer(Command.RESPONSE, STATUS_UNLOCKED_DOOR_OPEN, key=aes_key)
+
+        await coordinator.async_refresh()
+
+        assert coordinator.data.locked is False
+        assert coordinator.data.sensor is None

--- a/tests/test_ble_protocol.py
+++ b/tests/test_ble_protocol.py
@@ -1,0 +1,569 @@
+"""Tests for the pure BLE wire protocol.
+
+ble_protocol.py is the one part of the local transport provable without a
+lock, so these are the tests that have to be thorough - everything downstream
+assumes the bytes are right.
+
+Two kinds of assertion here, and the distinction matters. Round-trip tests
+(encode then decode) prove self-consistency but would pass just as happily if
+both halves were wrong in the same way. So the pieces that can be checked
+against something outside this repo are: crc8_maxim against the published
+CRC-8/MAXIM check value, the cipher against an independently constructed ECB
+computation, and the parses against what a real KT170 sent for a state the
+cloud reported at the same moment. Those are the ones that would catch a
+genuinely wrong protocol.
+"""
+
+import base64
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+import pytest
+
+from custom_components.ttlock.ble_protocol import (
+    HEADER_LENGTH,
+    MAGIC,
+    MAX_DATA_LENGTH,
+    TERMINATOR,
+    ChecksumError,
+    Command,
+    DecryptError,
+    DeviceFeatures,
+    Frame,
+    FrameAssembler,
+    FrameError,
+    LockStatus,
+    LockVersion,
+    Response,
+    UnsupportedProtocol,
+    crc8_maxim,
+    decrypt,
+    encrypt,
+    feature_value_bytes,
+    parse_aes_key,
+)
+
+from .const import MOCK_LOCK_VERSION
+
+KEY = bytes(range(16))
+VERSION = LockVersion(
+    protocol_type=5, protocol_version=3, scene=2, group_id=10, org_id=34
+)
+
+#: What a real KT170 answered an encrypted QUERY_LOCK_STATUS with, byte for
+#: byte. The lock was locked, its door shut, and the cloud said
+#: `electricQuantity: 100`, `state: 0`, `sensorState: 1` at the same moment -
+#: which is what decoded it, and what these tests are really asserting.
+KT170_STATUS_REPLY = bytes([0x14, 0x01, 0x64, 0x00, 0x01])
+
+#: What the same lock answered a *cleartext* SEARCH_DEVICE_FEATURE with, after
+#: decryption. The cloud said `electricQuantity: 100`,
+#: `featureValue: "800C2D4435CCF5F7"` and `specialValue: 902624759` for the
+#: same lock at the same moment, and 902624759 is 0x35CCF5F7 exactly.
+KT170_FEATURE_REPLY = bytes.fromhex("01016435ccf5f7800c2d440000000000000000")
+
+#: What `lock/detail` reported for that lock, verbatim.
+KT170_FEATURE_VALUE = "800C2D4435CCF5F7"
+KT170_SPECIAL_VALUE = 902624759
+
+
+class TestCrc8Maxim:
+    def test_the_published_check_value(self):
+        """Every CRC-8/MAXIM implementation agrees on this one."""
+        assert crc8_maxim(b"123456789") == 0xA1
+
+    def test_no_bytes(self):
+        assert crc8_maxim(b"") == 0
+
+    def test_a_single_zero_byte(self):
+        """Distinguishes MAXIM from variants with a non-zero init."""
+        assert crc8_maxim(b"\x00") == 0
+
+    def test_it_is_not_a_sum(self):
+        """Byte order has to matter, or it isn't a CRC at all."""
+        assert crc8_maxim(b"\x01\x02") != crc8_maxim(b"\x02\x01")
+
+    def test_it_stays_within_a_byte(self):
+        assert all(0 <= crc8_maxim(bytes([n])) <= 0xFF for n in range(256))
+
+
+class TestParseAesKey:
+    """aesKeyStr's encoding is undocumented, so every plausible one parses."""
+
+    def test_hex(self):
+        assert parse_aes_key(KEY.hex()) == KEY
+
+    def test_upper_case_hex(self):
+        assert parse_aes_key(KEY.hex().upper()) == KEY
+
+    @pytest.mark.parametrize("separator", [":", "-", ",", ".", " "])
+    def test_delimited_hex(self, separator):
+        assert parse_aes_key(separator.join(f"{b:02x}" for b in KEY)) == KEY
+
+    def test_the_shape_a_real_lock_returned(self):
+        """A KT170's aesKeyStr is 47 characters: 32 hex digits and 15 commas."""
+        delimited = ",".join(f"{b:02x}" for b in KEY)
+
+        assert len(delimited) == 47
+        assert parse_aes_key(delimited) == KEY
+
+    def test_all_numeric_hex_is_not_read_as_a_byte_list(self):
+        """The collision that hardware turned from theoretical into relevant.
+
+        "12,34,..." is a valid reading as comma-delimited hex *and* as a list
+        of decimal bytes, and the two give different keys. Nothing in the
+        string distinguishes them, so the tie is broken by evidence: a real
+        KT170 sends comma-delimited hex, and a key silently decoded as the
+        other form would fail on the air with no diagnosis to offer.
+        """
+        key = bytes([0x12, 0x34, 0x56, 0x78] * 4)
+        delimited = ",".join(f"{b:02x}" for b in key)
+
+        assert all(token.isdigit() for token in delimited.split(","))
+        assert parse_aes_key(delimited) == key
+
+    def test_a_negative_value_is_not_read_as_a_separator(self):
+        """The one way the two forms could collide, and the reason for the order.
+
+        Stripping "-" as a separator before trying the signed-byte list would
+        turn every negative into its absolute value - still 16 bytes, still
+        parsing cleanly, and wrong.
+        """
+        key = bytes([0x80] + [0x01] * 15)
+        signed = ",".join(str(b - 256 if b > 127 else b) for b in key)
+
+        assert parse_aes_key(signed) == key
+
+    def test_base64(self):
+        assert parse_aes_key(base64.b64encode(KEY).decode()) == KEY
+
+    def test_javas_signed_bytes(self):
+        """Java has no unsigned byte, so its SDK prints 0x80-0xff as negatives."""
+        key = bytes([0x80, 0xFF, 0x00, 0x7F] * 4)
+        signed = ",".join(str(b - 256 if b > 127 else b) for b in key)
+
+        assert parse_aes_key(signed) == key
+
+    def test_unsigned_decimal_bytes_too(self):
+        """Some tools print the same list without wrapping to signed."""
+        key = bytes([0x80, 0xFF, 0x00, 0x7F] * 4)
+
+        assert parse_aes_key(",".join(str(b) for b in key)) == key
+
+    def test_surrounding_whitespace(self):
+        assert parse_aes_key(f"  {KEY.hex()}\n") == KEY
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "   ",
+            "not a key at all",
+            "0f1e2d",  # valid hex, wrong length
+            "1,2,3",  # valid list, wrong length
+            "300,1,2",
+        ],
+    )
+    def test_anything_else_is_rejected(self, value):
+        """Wrong beats plausible: a mis-decoded key fails silently on the air."""
+        with pytest.raises(ValueError):
+            parse_aes_key(value)
+
+
+class TestCipher:
+    def test_the_iv_is_the_key(self):
+        """TTLock's defining cipher quirk, checked without reusing encrypt().
+
+        CBC XORs the IV into the first block before the block cipher runs, so
+        if the IV really is the key, the first ciphertext block must equal
+        ECB(key, plaintext XOR key).
+        """
+        plaintext = b"sixteen bytes!!!"
+
+        ecb = Cipher(algorithms.AES(KEY), modes.ECB()).encryptor()
+        expected = (
+            ecb.update(bytes(p ^ k for p, k in zip(plaintext, KEY, strict=True)))
+            + ecb.finalize()
+        )
+
+        assert encrypt(KEY, plaintext)[:16] == expected
+
+    def test_round_trip(self):
+        assert decrypt(KEY, encrypt(KEY, b"payload")) == b"payload"
+
+    def test_round_trip_of_an_exact_block(self):
+        """PKCS7 adds a whole extra block here - the case that trips zero-padding."""
+        plaintext = b"sixteen bytes!!!"
+
+        assert len(encrypt(KEY, plaintext)) == 32
+        assert decrypt(KEY, encrypt(KEY, plaintext)) == plaintext
+
+    def test_round_trip_of_nothing(self):
+        assert decrypt(KEY, encrypt(KEY, b"")) == b""
+
+    def test_the_wrong_key_is_rejected_rather_than_returning_rubbish(self):
+        ciphertext = encrypt(KEY, b"payload")
+
+        with pytest.raises(DecryptError):
+            decrypt(bytes(16), ciphertext)
+
+    def test_a_partial_block_is_rejected(self):
+        with pytest.raises(DecryptError):
+            decrypt(KEY, b"not a block")
+
+    def test_an_empty_payload_is_rejected(self):
+        with pytest.raises(DecryptError):
+            decrypt(KEY, b"")
+
+    @pytest.mark.parametrize("length", [8, 15, 17, 32])
+    def test_keys_must_be_16_bytes(self, length):
+        with pytest.raises(ValueError, match="16 bytes"):
+            encrypt(bytes(length), b"payload")
+
+
+class TestLockVersion:
+    def test_from_the_cloud_payload(self):
+        assert LockVersion.from_cloud(MOCK_LOCK_VERSION) == VERSION
+
+    def test_a_missing_field_is_named(self):
+        payload = {k: v for k, v in MOCK_LOCK_VERSION.items() if k != "orgId"}
+
+        with pytest.raises(ValueError, match="orgId"):
+            LockVersion.from_cloud(payload)
+
+
+class TestFrameEncoding:
+    def test_the_header_lays_out_as_documented(self):
+        raw = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"hi").encode()
+
+        assert raw[:2] == MAGIC
+        assert raw[2] == 5  # protocol type
+        assert raw[3] == 3  # protocol version
+        assert raw[4] == 2  # scene
+        assert raw[5:7] == (10).to_bytes(2, "big")  # group id
+        assert raw[7:9] == (34).to_bytes(2, "big")  # org id
+        assert raw[9] == Command.QUERY_LOCK_STATUS
+        assert raw[10] == 0  # scramble key: AES locks leave this clear
+        assert raw[11] == 2  # payload length
+        assert raw[HEADER_LENGTH : HEADER_LENGTH + 2] == b"hi"
+        assert raw[-2:] == TERMINATOR
+
+    def test_the_declared_length_is_of_the_ciphertext_not_the_plaintext(self):
+        """The lock counts the bytes on the wire, which padding makes longer."""
+        raw = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"hi").encode(KEY)
+
+        assert raw[11] == 16
+        assert len(raw) == HEADER_LENGTH + 16 + 3
+
+    def test_round_trip_in_the_clear(self):
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"probe")
+
+        assert Frame.decode(frame.encode()) == frame
+
+    def test_round_trip_encrypted(self):
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"secret payload")
+
+        assert Frame.decode(frame.encode(KEY), KEY) == frame
+
+    def test_an_empty_payload_round_trips_encrypted(self):
+        """Padding means even nothing becomes a block - decode must undo that."""
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS)
+
+        assert Frame.decode(frame.encode(KEY), KEY) == frame
+
+    def test_an_unknown_opcode_survives_the_round_trip(self):
+        """Command is a partial list; a lock may use one we haven't named."""
+        frame = Frame(VERSION, 0xFE, b"?")
+
+        assert Frame.decode(frame.encode()).command == 0xFE
+
+    def test_an_oversized_payload_is_refused(self):
+        with pytest.raises(ValueError, match="length field"):
+            Frame(
+                VERSION, Command.QUERY_LOCK_STATUS, bytes(MAX_DATA_LENGTH + 1)
+            ).encode()
+
+    def test_the_largest_payload_that_fits_is_allowed(self):
+        frame = Frame(VERSION, Command.QUERY_LOCK_STATUS, bytes(MAX_DATA_LENGTH))
+
+        assert Frame.decode(frame.encode()) == frame
+
+
+class TestFrameDecoding:
+    @pytest.fixture
+    def raw(self) -> bytes:
+        return Frame(VERSION, Command.QUERY_LOCK_STATUS, b"payload").encode()
+
+    def test_a_corrupted_payload_is_caught_by_the_crc(self, raw):
+        tampered = bytearray(raw)
+        tampered[HEADER_LENGTH] ^= 0xFF
+
+        with pytest.raises(ChecksumError):
+            Frame.decode(bytes(tampered))
+
+    def test_the_frame_that_failed_comes_with_the_complaint(self, raw):
+        """Two readings of a CRC failure, and only the bytes separate them.
+
+        Hardware produced one that passed the magic, the terminator and the
+        declared length - so not a byte corrupted in flight, which would have
+        broken the alignment as well. The header in the reported frame says
+        whether the assembler cut in the wrong place.
+        """
+        tampered = bytearray(raw)
+        tampered[HEADER_LENGTH] ^= 0xFF
+
+        with pytest.raises(ChecksumError, match=bytes(tampered).hex()):
+            Frame.decode(bytes(tampered))
+
+    def test_a_corrupted_header_is_caught_by_the_crc(self, raw):
+        tampered = bytearray(raw)
+        tampered[4] ^= 0xFF  # scene
+
+        with pytest.raises(ChecksumError):
+            Frame.decode(bytes(tampered))
+
+    def test_a_bad_magic_is_rejected(self, raw):
+        with pytest.raises(FrameError, match="start with"):
+            Frame.decode(b"\x00\x00" + raw[2:])
+
+    def test_a_missing_terminator_is_rejected(self, raw):
+        with pytest.raises(FrameError, match="end with"):
+            Frame.decode(raw[:-2] + b"\x00\x00")
+
+    def test_too_few_bytes_to_be_a_frame(self):
+        with pytest.raises(FrameError, match="too short"):
+            Frame.decode(MAGIC + bytes(5))
+
+    def test_a_length_that_disagrees_with_the_frame_is_rejected(self, raw):
+        """Catches a truncated frame that happens to end in CR+LF."""
+        lying = bytearray(raw)
+        lying[11] += 1
+
+        with pytest.raises(FrameError, match="declares"):
+            Frame.decode(bytes(lying))
+
+    def test_legacy_xor_locks_are_refused_loudly(self):
+        """Decoding these as AES would yield convincing garbage."""
+        raw = Frame(
+            VERSION, Command.QUERY_LOCK_STATUS, b"payload", scramble_key=0x42
+        ).encode()
+
+        with pytest.raises(UnsupportedProtocol, match="0x42"):
+            Frame.decode(raw)
+
+    def test_the_wrong_key_surfaces_as_a_decrypt_error(self):
+        """Distinct from ChecksumError: the frame arrived intact, we just can't read it."""
+        raw = Frame(VERSION, Command.QUERY_LOCK_STATUS, b"payload").encode(KEY)
+
+        with pytest.raises(DecryptError):
+            Frame.decode(raw, bytes(16))
+
+
+class TestFrameAssembler:
+    @pytest.fixture
+    def assembler(self) -> FrameAssembler:
+        return FrameAssembler()
+
+    @pytest.fixture
+    def frame(self) -> bytes:
+        """A frame longer than one BLE notification, as a real one would be.
+
+        An encrypted payload is a whole number of 16-byte blocks, so the
+        shortest real frame is 12 + 16 + 3 = 31 bytes - already too big for a
+        single ~20-byte notification. Reassembly is the normal case here, not
+        the edge case, so the fixture has to be long enough to need it.
+        """
+        return Frame(VERSION, Command.QUERY_LOCK_STATUS, b"state").encode(KEY)
+
+    def test_a_whole_frame_fed_in_one_piece(self, assembler, frame):
+        assert assembler.feed(frame) == [frame]
+
+    def test_nothing_is_emitted_until_the_frame_is_complete(self, assembler, frame):
+        assert assembler.feed(frame[:-1]) == []
+        assert assembler.feed(frame[-1:]) == [frame]
+
+    def test_a_frame_split_across_twenty_byte_notifications(self, assembler, frame):
+        """The real case: a BLE notification carries about 20 bytes."""
+        chunks = [frame[i : i + 20] for i in range(0, len(frame), 20)]
+        assert len(chunks) > 1
+
+        emitted = [f for chunk in chunks for f in assembler.feed(chunk)]
+
+        assert emitted == [frame]
+
+    def test_two_frames_arriving_together(self, assembler, frame):
+        assert assembler.feed(frame + frame) == [frame, frame]
+
+    def test_a_notification_carrying_the_tail_of_one_frame_and_the_head_of_the_next(
+        self, assembler, frame
+    ):
+        assembler.feed((frame + frame)[:-5])
+
+        assert assembler.feed(frame[-5:]) == [frame]
+
+    def test_it_resynchronises_past_leading_junk(self, assembler, frame):
+        """Connecting mid-response shouldn't cost more than the frame in flight."""
+        assert assembler.feed(b"\x11\x22\x33" + frame) == [frame]
+
+    def test_a_magic_split_across_two_notifications(self, assembler, frame):
+        """The one byte the buffer must hold on to when it sees no frame start."""
+        assembler.feed(b"junk" + frame[:1])
+
+        assert assembler.feed(frame[1:]) == [frame]
+
+    def test_magic_free_noise_does_not_accumulate(self, assembler, frame):
+        for _ in range(50):
+            assert assembler.feed(bytes(20)) == []
+
+        assert assembler.feed(frame) == [frame]
+
+    def test_a_corrupt_frame_does_not_desynchronise_what_follows(
+        self, assembler, frame
+    ):
+        """Cutting the stream up is kept separate from validating it, for this."""
+        corrupt = bytearray(frame)
+        corrupt[HEADER_LENGTH] ^= 0xFF
+
+        emitted = assembler.feed(bytes(corrupt) + frame)
+
+        assert len(emitted) == 2
+        with pytest.raises(ChecksumError):
+            Frame.decode(emitted[0])
+        assert Frame.decode(emitted[1]) == Frame.decode(frame)
+
+    def test_reset_drops_a_partial_frame(self, assembler, frame):
+        assembler.feed(frame[:8])
+
+        assembler.reset()
+
+        assert assembler.feed(frame[8:]) == []
+
+
+class TestResponse:
+    """The reply envelope: which command, then whether it worked."""
+
+    def test_the_reply_a_real_lock_sent(self):
+        response = Response.parse(KT170_STATUS_REPLY)
+
+        assert response.command == Command.QUERY_LOCK_STATUS
+        assert response.succeeded is True
+        assert response.data == b"\x64\x00\x01"
+
+    def test_a_refusal(self):
+        response = Response.parse(bytes([0x41, 0x00]))
+
+        assert response.command == 0x41
+        assert response.succeeded is False
+        assert response.data == b""
+
+    def test_an_unrecognised_opcode_arrives_intact(self):
+        """Same rule as Frame.command - decode it, do not raise over it."""
+        assert Response.parse(b"\xfe\x01").command == 0xFE
+
+    def test_a_truncated_reply_claims_nothing(self):
+        response = Response.parse(b"")
+
+        assert response.command is None
+        assert response.succeeded is None
+        assert response.data == b""
+
+
+class TestLockStatus:
+    """The parse that made an authenticated session unnecessary for M2."""
+
+    def test_the_reply_a_real_lock_sent(self):
+        """Three values, each confirmed against the cloud's answer for the
+        same lock at the same moment. That agreement is the whole proof.
+        """
+        status = LockStatus.parse(KT170_STATUS_REPLY)
+
+        assert status.battery == 100
+        assert status.locked is True
+        assert status.door_open is False
+
+    def test_an_unlocked_lock(self):
+        status = LockStatus.parse(bytes([0x14, 0x01, 0x50, 0x01, 0x00]))
+
+        assert status.battery == 80
+        assert status.locked is False
+        assert status.door_open is True
+
+    def test_an_unknown_state_is_not_reported_as_either(self):
+        """2 is the cloud's "unknown", and guessing it is how a shut door gets
+        reported as open.
+        """
+        status = LockStatus.parse(bytes([0x14, 0x01, 0x64, 0x02, 0x02]))
+
+        assert status.battery == 100
+        assert status.locked is None
+        assert status.door_open is None
+
+    def test_a_lock_with_no_door_sensor_says_nothing_about_one(self):
+        status = LockStatus.parse(bytes([0x14, 0x01, 0x64, 0x00]))
+
+        assert status.locked is True
+        assert status.door_open is None
+
+    def test_an_empty_reply_does_not_raise(self):
+        assert LockStatus.parse(b"") == LockStatus(None, None, None)
+
+
+class TestDeviceFeatures:
+    """The other unauthenticated reply, and the endianness it exposed."""
+
+    def test_the_reply_a_real_lock_sent(self):
+        """Every field cross-checked against `lock/detail` for the same lock.
+
+        That agreement is the proof, not the parse: three independent values
+        the cloud reported separately all land where this says they should.
+        """
+        features = DeviceFeatures.parse(KT170_FEATURE_REPLY)
+
+        assert features.battery == 100
+        assert features.special_value == KT170_SPECIAL_VALUE
+        assert features.feature_value == 0x800C2D44
+        assert features.extra == bytes(8)
+
+    def test_the_cloud_s_feature_value_is_two_numbers(self):
+        """The find. `featureValue` is the feature bits and `specialValue`
+        concatenated - which is why the halves have to be swapped to compare
+        it against anything off the radio.
+        """
+        features = DeviceFeatures.parse(KT170_FEATURE_REPLY)
+        assert features.feature_value is not None
+        assert features.special_value is not None
+
+        combined = (features.feature_value << 32) | features.special_value
+
+        assert combined == int(KT170_FEATURE_VALUE, 16)
+
+    def test_a_truncated_reply_reports_unknown_rather_than_raising(self):
+        features = DeviceFeatures.parse(bytes([0x01, 0x01, 0x64]))
+
+        assert features.battery == 100
+        assert features.special_value is None
+        assert features.feature_value is None
+
+    def test_an_empty_reply_does_not_raise(self):
+        assert DeviceFeatures.parse(b"") == DeviceFeatures(None, None, None, b"")
+
+
+class TestFeatureValueBytes:
+    """The swap, isolated - it is the whole of a check that must not lie."""
+
+    def test_it_matches_what_the_lock_actually_sent(self):
+        """Before this, a comparison read false on a payload that had decrypted
+        perfectly: a false negative on the one check proving the key encoding,
+        the IV convention, the cipher mode and the padding.
+        """
+        expected = feature_value_bytes(KT170_FEATURE_VALUE)
+
+        assert expected in KT170_FEATURE_REPLY
+
+    def test_the_cloud_s_own_byte_order_is_not_in_the_reply(self):
+        """The failure this replaced, kept so a revert cannot pass quietly."""
+        assert bytes.fromhex(KT170_FEATURE_VALUE) not in KT170_FEATURE_REPLY
+
+    @pytest.mark.parametrize("value", ["", "not hex", "800C2D44", "800C2D4435CCF5F7FF"])
+    def test_anything_unexpected_turns_the_check_off(self, value):
+        """Empty disables the comparison; raising would fail a dump over it."""
+        assert feature_value_bytes(value) == b""


### PR DESCRIPTION
Second slice of M2 from discussion #325. **Stacked on #331** (`ble_protocol.py`) — the diff shows both commits until #331 lands; only `254fad7` is new here.

## What

A lock in Bluetooth range now answers the coordinator's fast tier locally. `QUERY_LOCK_STATUS` returns lock, battery and door state, is encrypted with the AES key `lock/detail` already returns, and needs no authenticated session. The cloud path is untouched and remains the fallback whenever the local read isn't possible: bluetooth not set up, lock not heard, credentials unusable, connect/write failure, or no reply.

- `ble.py`: `async_connect`/`async_disconnect` via `bleak-retry-connector` (deferred imports, gated the same way as presence), `LockSession` (subscribe → MTU-chunked write → reassembled reply, one command at a time), `async_command_session`, `async_read_status`.
- `coordinator.py`: keeps `lockVersion`/`aesKeyStr` from the slow-tier `lock/detail`; `async_read_state_ble()` never raises; the fast tier tries it before `get_lock_state`. Door state merges only when a sensor is present.
- `models.Lock`: `lockVersion`, `aesKeyStr` (already in `TO_REDACT`).
- `manifest.json`: `bleak-retry-connector>=4.4.0`.
- Tests: `GattRecorder`/`mock_gatt` fixtures in conftest, a `SpeakingLock` that plays the lock's side, session/encryption/read/coordinator tests. `mock_bluetooth` now also stubs `async_ble_device_from_address`.

## Deliberately not here

- No warm/persistent link, no push events, no lock/unlock — the write half closed negative on hardware (developer credentials don't include `unlockKey`), see #325.
- No separate battery-characteristic read; the status reply carries battery.
- No diagnostics changes.

## Verified

`script/check` clean, 419 passed. On a KT170 with the gateway unplugged the poll reports lock/battery/door from the local read; with bluetooth absent or the lock out of range the behaviour is byte-for-byte the previous cloud poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
