### PR TITLE
ble: keep a lock usable while the radio can reach it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ A Home Assistant integration bridging TTLock's cloud API into HA entities and se
 ## Language
 
 **Connectable**:
-Whether TTLock's cloud can currently reach a lock — via a paired gateway or the lock's own WiFi radio. Decided once when the lock is discovered; a non-connectable lock is never polled again on the assumption connectivity won't change until the integration reloads.
+Whether anything can currently reach a lock: TTLock's cloud (via a paired gateway or the lock's own WiFi radio) or Home Assistant's own Bluetooth radio (the lock is advertising in range, or a recent local read succeeded). The cloud half is decided once when the lock is discovered; the Bluetooth half changes while running, and polling starts and stops to match.
 _Avoid_: reachable, online (online/offline is used for gateways specifically, a separate concept)
 
 **Discovery**:

--- a/custom_components/ttlock/__init__.py
+++ b/custom_components/ttlock/__init__.py
@@ -141,8 +141,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if skipped := [coordinator for coordinator in locks if not coordinator.connectable]:
         _LOGGER.warning(
-            "%d lock(s) have no gateway or WiFi and will show as unavailable "
-            "until connectivity is restored: %s",
+            "%d lock(s) have no gateway or WiFi and are not in Bluetooth range; "
+            "they will show as unavailable until one of those changes: %s",
             len(skipped),
             ", ".join(
                 f"{coordinator.data.name} ({coordinator.lock_id})"

--- a/custom_components/ttlock/config_flow.py
+++ b/custom_components/ttlock/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
@@ -23,9 +24,11 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
+    CONF_BLUETOOTH_ENABLED,
     CONF_POLL_INTERVAL,
     CONF_REGION,
     CONF_SLOW_POLL_INTERVAL,
+    DEFAULT_BLUETOOTH_ENABLED,
     DEFAULT_POLL_INTERVAL_MINUTES,
     DEFAULT_REGION,
     DEFAULT_SLOW_POLL_INTERVAL_HOURS,
@@ -96,25 +99,26 @@ class TTLockAuthFlowHandler(
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        """Get the options flow for tuning polling cadence."""
+        """Get the options flow for polling cadence and Bluetooth."""
         return TTLockOptionsFlow()
 
 
 class TTLockOptionsFlow(OptionsFlow):
-    """Let users tune how often the integration polls the TTLock cloud.
+    """Let users tune how the integration reaches their locks.
 
-    Two knobs, both global to the account entry: the fast poll interval that
-    re-verifies lock state, and the slow interval that governs how often
-    detail/passage/gateway data is re-fetched (see coordinator.py). Defaults
-    are gentle because webhooks carry real-time changes; users whose webhooks
-    are unreliable can dial the fast interval back down. Changing either
+    Three knobs, all global to the account entry: the fast poll interval
+    that re-verifies lock state, the slow interval that governs how often
+    detail/passage/gateway data is re-fetched (see coordinator.py), and
+    whether locks may be read over Bluetooth at all. Defaults are gentle
+    because webhooks carry real-time changes; users whose webhooks are
+    unreliable can dial the fast interval back down. Changing any of them
     reloads the entry so new coordinators pick the values up.
     """
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Manage the polling-cadence options."""
+        """Manage the polling and Bluetooth options."""
         if user_input is not None:
             return self.async_create_entry(data=user_input)
 
@@ -159,6 +163,12 @@ class TTLockOptionsFlow(OptionsFlow):
                         ),
                         vol.Coerce(int),
                     ),
+                    vol.Required(
+                        CONF_BLUETOOTH_ENABLED,
+                        default=options.get(
+                            CONF_BLUETOOTH_ENABLED, DEFAULT_BLUETOOTH_ENABLED
+                        ),
+                    ): BooleanSelector(),
                 }
             ),
         )

--- a/custom_components/ttlock/const.py
+++ b/custom_components/ttlock/const.py
@@ -44,6 +44,11 @@ CONF_SLOW_POLL_INTERVAL = "slow_poll_interval"
 DEFAULT_POLL_INTERVAL_MINUTES = 30
 DEFAULT_SLOW_POLL_INTERVAL_HOURS = 6
 
+# Local Bluetooth reads, tunable via the same options flow. On by default;
+# off leaves the lock reachable over the cloud only.
+CONF_BLUETOOTH_ENABLED = "bluetooth_enabled"
+DEFAULT_BLUETOOTH_ENABLED = True
+
 SIGNAL_NEW_DATA = f"{DOMAIN}.data_received"
 
 DEVICE_LOGGER_PREFIX = f"{__package__}.device."

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -64,9 +64,15 @@ from .store import LockStateStore
 _LOGGER = logging.getLogger(__name__)
 
 NOT_CONNECTABLE_REASON = (
-    "No gateway paired and no WiFi — TTLock's cloud can't reach this lock. "
-    "Live data isn't available until connectivity is restored."
+    "No gateway paired, no WiFi, and not in Bluetooth range of Home Assistant - "
+    "nothing can reach this lock. Live data isn't available until one of those "
+    "changes."
 )
+
+# A lock the radio can still hear rides out this many failed state reads,
+# retried at this cadence, before it goes unavailable.
+RETRY_INTERVAL = timedelta(minutes=1)
+REVERIFY_GRACE = 2
 
 # TTLock's doorSensor/query can't distinguish "no sensor paired" from a
 # transient failure (see api.get_sensor), so a lock only counts as confirmed
@@ -236,7 +242,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         """Initialize the update co-ordinator for a single lock."""
         self.api = api
         self.lock_id = summary.id
-        self.connectable = summary.connectable
+        self.cloud_connectable = summary.connectable
         self.has_gateway = summary.hasGateway
         self.feature_value = summary.featureValue
         self._capture = capture
@@ -246,6 +252,8 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         # Empty until async_start_ble_tracking hears the first
         # advertisement (or immediately, if the stack already has one)
         self.ble: BleData = BleData()
+        self._ble_verified_at: datetime | None = None
+        self._reverify_failures = 0
 
         # What lock/detail told us about talking to the lock directly. Kept
         # as received; parsed on use so an odd value costs a local read, not
@@ -268,19 +276,23 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         slow_hours = options.get(
             CONF_SLOW_POLL_INTERVAL, DEFAULT_SLOW_POLL_INTERVAL_HOURS
         )
+        self._poll_interval = timedelta(minutes=poll_minutes)
         self._slow_interval = timedelta(hours=slow_hours)
         self._details_last_fetched: datetime | None = None
         self._passage_last_fetched: datetime | None = None
         self._gateways_last_fetched: datetime | None = None
+
+        # A successful local read vouches for the lock this long - longer
+        # than the poll, so a healthy lock isn't unproven while waiting for
+        # the poll that would confirm it.
+        self._proven_reachable_for = 2 * self._poll_interval
 
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             config_entry=config_entry,
-            update_interval=(
-                timedelta(minutes=poll_minutes) if self.connectable else None
-            ),
+            update_interval=self._poll_interval if self.connectable else None,
         )
 
         self.data = LockState(
@@ -302,15 +314,68 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             return lambda: None
         return async_track_address(self.hass, self.data.mac, self._async_ble_updated)
 
+    @property
+    def ble_proven(self) -> bool:
+        """Whether a local read succeeded recently enough to vouch for the lock.
+
+        TTLock locks advertise in bursts minutes apart, so a completed read
+        is better evidence of reachability than the age of the last packet.
+        """
+        if self._ble_verified_at is None:
+            return False
+        return dt_util.utcnow() - self._ble_verified_at <= self._proven_reachable_for
+
+    @property
+    def ble_reachable(self) -> bool:
+        """Whether the local radio can reach the lock right now."""
+        return self.ble_proven or (self.ble.in_range and self.ble.connectable)
+
+    @property
+    def connectable(self) -> bool:
+        """Whether anything - cloud or radio - can reach the lock."""
+        return self.cloud_connectable or self.ble_reachable
+
     @callback
     def _async_ble_updated(self, ble: BleData) -> None:
         """Record new presence and let entities re-read it.
 
-        This is passive - a presence change never triggers a cloud poll or a
-        connection, it only refreshes what the RSSI sensor reports.
+        Advertisements themselves never trigger a poll or a connection; only
+        the lock becoming (un)reachable starts or stops the poll.
         """
+        was_connectable = self.connectable
         self.ble = ble
         self.async_update_listeners()
+        if self.connectable != was_connectable:
+            self._async_reconcile_polling()
+
+    @callback
+    def _async_reconcile_polling(self) -> None:
+        """Start or stop the poll to match what can reach the lock now."""
+        if not self.connectable:
+            self.update_interval = None
+            return
+        self.update_interval = self._poll_interval
+        self.hass.async_create_task(self.async_request_refresh())
+
+    @callback
+    def _async_note_verified(self) -> None:
+        self._reverify_failures = 0
+        if self.update_interval == RETRY_INTERVAL:
+            self.update_interval = self._poll_interval
+
+    @callback
+    def _async_tolerate_failed_verification(self) -> bool:
+        """Whether to keep the last known state after a failed state read.
+
+        Only for a lock the radio can still hear: one connection that didn't
+        take says nothing about the bolt. A lock nothing can hear goes
+        unavailable on the first failure, as before.
+        """
+        if not self.ble_reachable:
+            return False
+        self._reverify_failures += 1
+        self.update_interval = RETRY_INTERVAL
+        return self._reverify_failures <= REVERIFY_GRACE
 
     def _ble_credentials(self) -> tuple[LockVersion, bytes] | None:
         """The protocol dialect and AES key, or None if lock/detail's aren't usable."""
@@ -328,24 +393,27 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         Never raises - the caller has the cloud to fall back on, and a lock that
         is out of range or not answering is expected, not exceptional.
         """
-        if not async_bluetooth_available(self.hass) or not self.ble.in_range:
+        if not async_bluetooth_available(self.hass) or not self.ble_reachable:
             return None
         credentials = self._ble_credentials()
         if credentials is None:
             return None
         version, aes_key = credentials
         try:
-            return await async_read_status(
+            status = await async_read_status(
                 self.hass, self.data.mac, self.data.name, version, aes_key
             )
         except (BleError, ProtocolError) as err:
             _LOGGER.debug("Local state read for lock %s failed: %s", self.lock_id, err)
+            self._ble_verified_at = None
             return None
+        self._ble_verified_at = dt_util.utcnow()
+        return status
 
     async def _async_update_data(self) -> LockState:
         if not self.connectable:
             raise UpdateFailed(
-                f"Lock {self.lock_id} has no gateway or WiFi connectivity"
+                f"Lock {self.lock_id} has no gateway, WiFi or Bluetooth route"
             )
 
         try:
@@ -390,6 +458,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             # without spending cloud quota; the cloud remains the fallback.
             status = await self.async_read_state_ble()
             if status is not None and status.locked is not None:
+                self._async_note_verified()
                 new_data.locked = status.locked
                 if status.battery is not None:
                     new_data.battery_level = status.battery
@@ -398,6 +467,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             else:
                 try:
                     state = await self.api.get_lock_state(self.lock_id)
+                    self._async_note_verified()
                     new_data.locked = state.locked == State.locked
                     if sensor_present(new_data.sensor):
                         new_data.sensor.opened = state.opened == SensorState.opened
@@ -406,6 +476,14 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
                         # first-ever fetch: tolerate failure, entity shows "unknown"
                         _LOGGER.debug(
                             "Failed to fetch initial lock state", exc_info=True
+                        )
+                    elif self._async_tolerate_failed_verification():
+                        _LOGGER.debug(
+                            "Keeping the last known state of lock %s after "
+                            "%d failed read(s)",
+                            self.lock_id,
+                            self._reverify_failures,
+                            exc_info=True,
                         )
                     else:
                         # we previously had a verified state - a failure to re-verify now
@@ -651,6 +729,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         return {
             "unique_id": self.unique_id,
             "connectable": self.connectable,
+            "cloud_connectable": self.cloud_connectable,
+            "ble_reachable": self.ble_reachable,
+            "ble_proven": self.ble_proven,
             "has_gateway": self.has_gateway,
             "feature_value": self.feature_value,
             "last_update_success": self.last_update_success,

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -39,8 +39,10 @@ from .ble import (
 from .ble_protocol import LockStatus, LockVersion, ProtocolError, parse_aes_key
 from .capture import LockTrafficCapture
 from .const import (
+    CONF_BLUETOOTH_ENABLED,
     CONF_POLL_INTERVAL,
     CONF_SLOW_POLL_INTERVAL,
+    DEFAULT_BLUETOOTH_ENABLED,
     DEFAULT_POLL_INTERVAL_MINUTES,
     DEFAULT_SLOW_POLL_INTERVAL_HOURS,
     DOMAIN,
@@ -70,7 +72,8 @@ NOT_CONNECTABLE_REASON = (
 )
 
 # A lock the radio can still hear rides out this many failed state reads,
-# retried at this cadence, before it goes unavailable.
+# retried at this cadence, before it goes unavailable and the poll returns
+# to its normal interval.
 RETRY_INTERVAL = timedelta(minutes=1)
 REVERIFY_GRACE = 2
 
@@ -278,6 +281,9 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         )
         self._poll_interval = timedelta(minutes=poll_minutes)
         self._slow_interval = timedelta(hours=slow_hours)
+        self._ble_option: bool = options.get(
+            CONF_BLUETOOTH_ENABLED, DEFAULT_BLUETOOTH_ENABLED
+        )
         self._details_last_fetched: datetime | None = None
         self._passage_last_fetched: datetime | None = None
         self._gateways_last_fetched: datetime | None = None
@@ -306,11 +312,12 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         """Begin watching this lock's Bluetooth presence.
 
         Returns an unsubscribe callable for the caller to register with
-        `entry.async_on_unload`. When the bluetooth component isn't set up
-        there is nothing to watch, so this is a no-op that returns a no-op -
-        the lock keeps working over the cloud exactly as before.
+        `entry.async_on_unload`. When Bluetooth is off, or the bluetooth
+        component isn't set up, there is nothing to watch, so this is a
+        no-op that returns a no-op - the lock keeps working over the cloud
+        exactly as before.
         """
-        if not async_bluetooth_available(self.hass):
+        if not self.ble_enabled:
             return lambda: None
         return async_track_address(self.hass, self.data.mac, self._async_ble_updated)
 
@@ -326,8 +333,15 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         return dt_util.utcnow() - self._ble_verified_at <= self._proven_reachable_for
 
     @property
+    def ble_enabled(self) -> bool:
+        """Whether local Bluetooth is on for this entry and the component is loaded."""
+        return self._ble_option and async_bluetooth_available(self.hass)
+
+    @property
     def ble_reachable(self) -> bool:
         """Whether the local radio can reach the lock right now."""
+        if not self._ble_option:
+            return False
         return self.ble_proven or (self.ble.in_range and self.ble.connectable)
 
     @property
@@ -358,10 +372,15 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         self.hass.async_create_task(self.async_request_refresh())
 
     @callback
-    def _async_note_verified(self) -> None:
-        self._reverify_failures = 0
+    def _async_resume_normal_polling(self) -> None:
+        """Drop back to the normal cadence after a burst of retries."""
         if self.update_interval == RETRY_INTERVAL:
             self.update_interval = self._poll_interval
+
+    @callback
+    def _async_note_verified(self) -> None:
+        self._reverify_failures = 0
+        self._async_resume_normal_polling()
 
     @callback
     def _async_tolerate_failed_verification(self) -> bool:
@@ -369,13 +388,18 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
 
         Only for a lock the radio can still hear: one connection that didn't
         take says nothing about the bolt. A lock nothing can hear goes
-        unavailable on the first failure, as before.
+        unavailable on the first failure. Retries are quick only while the
+        grace lasts - past it the lock is unavailable either way, and dialling
+        it every minute just spends its battery.
         """
         if not self.ble_reachable:
             return False
         self._reverify_failures += 1
+        if self._reverify_failures > REVERIFY_GRACE:
+            self._async_resume_normal_polling()
+            return False
         self.update_interval = RETRY_INTERVAL
-        return self._reverify_failures <= REVERIFY_GRACE
+        return True
 
     def _ble_credentials(self) -> tuple[LockVersion, bytes] | None:
         """The protocol dialect and AES key, or None if lock/detail's aren't usable."""
@@ -393,7 +417,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         Never raises - the caller has the cloud to fall back on, and a lock that
         is out of range or not answering is expected, not exceptional.
         """
-        if not async_bluetooth_available(self.hass) or not self.ble_reachable:
+        if not self.ble_enabled or not self.ble_reachable:
             return None
         credentials = self._ble_credentials()
         if credentials is None:
@@ -730,6 +754,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
             "unique_id": self.unique_id,
             "connectable": self.connectable,
             "cloud_connectable": self.cloud_connectable,
+            "ble_enabled": self.ble_enabled,
             "ble_reachable": self.ble_reachable,
             "ble_proven": self.ble_proven,
             "has_gateway": self.has_gateway,

--- a/custom_components/ttlock/sensor.py
+++ b/custom_components/ttlock/sensor.py
@@ -21,7 +21,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .ble import async_bluetooth_available
 from .coordinator import async_add_when_sensor_present, lock_coordinators
 from .entity import BaseLockEntity
 
@@ -37,8 +36,6 @@ async def async_setup_entry(
 
     coordinators = list(lock_coordinators(hass, entry))
 
-    with_bluetooth = async_bluetooth_available(hass)
-
     async_add_entities(
         [
             entity
@@ -48,7 +45,7 @@ async def async_setup_entry(
                 LockOperator(coordinator),
                 LockTrigger(coordinator),
                 *([LockGateway(coordinator)] if coordinator.has_gateway else []),
-                *([LockBleSignal(coordinator)] if with_bluetooth else []),
+                *([LockBleSignal(coordinator)] if coordinator.ble_enabled else []),
             )
         ]
     )

--- a/custom_components/ttlock/translations/en.json
+++ b/custom_components/ttlock/translations/en.json
@@ -33,15 +33,17 @@
   "options": {
     "step": {
       "init": {
-        "title": "Polling cadence",
-        "description": "How often the integration polls the TTLock cloud. Locks also update in near real time via webhooks, so these can stay high to keep multi-lock accounts under TTLock's free-tier API-call limit. Lower the poll interval if your webhooks are unreliable.",
+        "title": "Polling and Bluetooth",
+        "description": "How often the integration polls the TTLock cloud, and whether it also reads locks over Bluetooth. Locks update in near real time via webhooks, so the intervals can stay high to keep multi-lock accounts under TTLock's free-tier API-call limit. Lower the poll interval if your webhooks are unreliable.",
         "data": {
           "poll_interval": "Poll interval",
-          "slow_poll_interval": "Detail refresh interval"
+          "slow_poll_interval": "Detail refresh interval",
+          "bluetooth_enabled": "Read locks over Bluetooth"
         },
         "data_description": {
           "poll_interval": "How often to re-check whether each lock is locked or unlocked, in minutes.",
-          "slow_poll_interval": "How often to refresh slow-changing detail (battery, name, autolock and passage-mode config, gateway signal), in hours."
+          "slow_poll_interval": "How often to refresh slow-changing detail (battery, name, autolock and passage-mode config, gateway signal), in hours.",
+          "bluetooth_enabled": "Read lock state directly from a lock in range of Home Assistant, instead of asking the TTLock cloud. Turn this off to use the cloud only."
         }
       }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,9 +141,10 @@ def new_mocked_entry():
     sharing one client_id.
     """
 
-    def _new_entry(**extra_data) -> MockConfigEntry:
+    def _new_entry(options=None, **extra_data) -> MockConfigEntry:
         return MockConfigEntry(
             domain=DOMAIN,
+            options=options or {},
             data={
                 "auth_implementation": "mocked",
                 "token": {

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -44,7 +44,11 @@ from custom_components.ttlock.ble_protocol import (
     parse_aes_key,
 )
 from custom_components.ttlock.capture import LockTrafficCapture
-from custom_components.ttlock.const import DEFAULT_POLL_INTERVAL_MINUTES, DOMAIN
+from custom_components.ttlock.const import (
+    CONF_BLUETOOTH_ENABLED,
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    DOMAIN,
+)
 from custom_components.ttlock.coordinator import RETRY_INTERVAL, LockUpdateCoordinator
 from custom_components.ttlock.models import Lock, LockSummary
 from custom_components.ttlock.store import LockStateStore
@@ -67,17 +71,27 @@ LOCK_NAME = "Front Door"
 
 POLL_INTERVAL = timedelta(minutes=DEFAULT_POLL_INTERVAL_MINUTES)
 
+BLUETOOTH_OFF = {CONF_BLUETOOTH_ENABLED: False}
 
-def _gatewayless(hass: HomeAssistant, api) -> LockUpdateCoordinator:
-    """A coordinator for a lock the cloud has no route to."""
-    config_entry = MockConfigEntry(domain=DOMAIN)
+
+def _coordinator(
+    hass: HomeAssistant, api, summary: LockSummary, options: dict | None = None
+) -> LockUpdateCoordinator:
+    config_entry = MockConfigEntry(domain=DOMAIN, options=options or {})
     config_entry.add_to_hass(hass)
-    summary = LockSummary(
-        lockId=1, lockAlias="No Gateway", lockMac=LOCK_MAC, hasGateway=0
-    )
     return LockUpdateCoordinator(
         hass, config_entry, api, summary, LockTrafficCapture(), LockStateStore(hass)
     )
+
+
+def _gatewayless(
+    hass: HomeAssistant, api, options: dict | None = None
+) -> LockUpdateCoordinator:
+    """A coordinator for a lock the cloud has no route to."""
+    summary = LockSummary(
+        lockId=1, lockAlias="No Gateway", lockMac=LOCK_MAC, hasGateway=0
+    )
+    return _coordinator(hass, api, summary, options)
 
 
 def _cloud_state_fails(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -763,6 +777,67 @@ class TestCoordinatorBleRead:
 
         assert coordinator.data.locked is False
         assert coordinator.data.sensor is None
+
+
+class TestBluetoothDisabled:
+    """Turning the option off leaves a lock reachable over the cloud only."""
+
+    @pytest.fixture
+    def cloud_backed(self, hass, api) -> LockUpdateCoordinator:
+        """A lock with a gateway, Bluetooth switched off for its entry."""
+        summary = LockSummary(
+            lockId=7252408,
+            lockAlias="Test Lock",
+            lockMac="00:00:00:00:00:00",
+            hasGateway=1,
+        )
+        return _coordinator(hass, api, summary, BLUETOOTH_OFF)
+
+    async def test_the_radio_is_on_by_default(self, hass, api, mock_bluetooth):
+        assert _gatewayless(hass, api).ble_enabled is True
+
+    async def test_the_option_alone_does_not_turn_the_radio_on(self, hass, api):
+        assert _gatewayless(hass, api).ble_enabled is False
+
+    async def test_a_disabled_radio_is_not_tracked(self, hass, api, mock_bluetooth):
+        unsubscribe = _gatewayless(hass, api, BLUETOOTH_OFF).async_start_ble_tracking()
+        unsubscribe()
+
+        assert mock_bluetooth.advertisement is None
+        assert mock_bluetooth.unsubscribed == []
+
+    async def test_a_disabled_radio_is_not_reachable(self, hass, api, mock_bluetooth):
+        gatewayless = _gatewayless(hass, api, BLUETOOTH_OFF)
+        gatewayless.ble = BleData(rssi=-60, connectable=True)
+
+        assert gatewayless.ble_reachable is False
+        assert gatewayless.connectable is False
+        assert gatewayless.update_interval is None
+
+    async def test_a_disabled_radio_leaves_the_cloud_to_answer(
+        self, cloud_backed, mock_api_responses, mock_bluetooth, speaking_lock, aes_key
+    ):
+        speaking_lock.answer(Command.RESPONSE, STATUS_LOCKED, key=aes_key)
+        cloud_backed.ble = BleData(rssi=-60, connectable=True)
+        mock_api_responses("default")
+
+        await cloud_backed.async_refresh()
+
+        assert cloud_backed.data.locked is False
+        assert speaking_lock.gatt.connects == 0
+
+    async def test_a_disabled_radio_gets_no_grace(
+        self, cloud_backed, mock_api_responses, mock_bluetooth, monkeypatch
+    ):
+        mock_api_responses("default")
+        await cloud_backed.async_refresh()
+        cloud_backed.ble = BleData(rssi=-60, connectable=True)
+        _cloud_state_fails(monkeypatch)
+
+        await cloud_backed.async_refresh()
+
+        assert cloud_backed.last_update_success is False
+        assert cloud_backed.update_interval == POLL_INTERVAL
 
 
 class TestCoordinatorReachability:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -14,10 +14,12 @@ with a recorder that plays the lock's side of the GATT conversation.
 
 from dataclasses import dataclass, field
 from datetime import timedelta
+from unittest.mock import AsyncMock, patch
 
 from bleak_retry_connector import BleakError
 from habluetooth import BluetoothScanningMode
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ttlock import ble
 from custom_components.ttlock.api import RequestFailed
@@ -41,7 +43,11 @@ from custom_components.ttlock.ble_protocol import (
     LockVersion,
     parse_aes_key,
 )
-from custom_components.ttlock.models import Lock
+from custom_components.ttlock.capture import LockTrafficCapture
+from custom_components.ttlock.const import DEFAULT_POLL_INTERVAL_MINUTES, DOMAIN
+from custom_components.ttlock.coordinator import RETRY_INTERVAL, LockUpdateCoordinator
+from custom_components.ttlock.models import Lock, LockSummary
+from custom_components.ttlock.store import LockStateStore
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -58,6 +64,30 @@ from .const import (
 ADVERTISEMENT = "advertisement"
 
 LOCK_NAME = "Front Door"
+
+POLL_INTERVAL = timedelta(minutes=DEFAULT_POLL_INTERVAL_MINUTES)
+
+
+def _gatewayless(hass: HomeAssistant, api) -> LockUpdateCoordinator:
+    """A coordinator for a lock the cloud has no route to."""
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    summary = LockSummary(
+        lockId=1, lockAlias="No Gateway", lockMac=LOCK_MAC, hasGateway=0
+    )
+    return LockUpdateCoordinator(
+        hass, config_entry, api, summary, LockTrafficCapture(), LockStateStore(hass)
+    )
+
+
+def _cloud_state_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def get_lock_state(self, lock_id):
+        raise RequestFailed("no gateway")
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_lock_state", get_lock_state
+    )
+
 
 # A KT170's answer to QUERY_LOCK_STATUS: the echoed opcode, success, then
 # battery 100%, locked, door closed.
@@ -626,16 +656,11 @@ class TestCoordinatorBleRead:
 
     @pytest.fixture
     def in_range(self, coordinator, mock_bluetooth):
-        coordinator.ble = BleData(rssi=-60)
+        coordinator.ble = BleData(rssi=-60, connectable=True)
 
     @pytest.fixture
     def cloud_unreachable(self, monkeypatch):
-        async def get_lock_state(self, lock_id):
-            raise RequestFailed("no gateway")
-
-        monkeypatch.setattr(
-            "custom_components.ttlock.api.TTLockApi.get_lock_state", get_lock_state
-        )
+        _cloud_state_fails(monkeypatch)
 
     @pytest.fixture
     def locked_locally(self, speaking_lock, aes_key):
@@ -738,3 +763,225 @@ class TestCoordinatorBleRead:
 
         assert coordinator.data.locked is False
         assert coordinator.data.sensor is None
+
+
+class TestCoordinatorReachability:
+    """A lock only the radio can reach is polled for as long as the radio hears it."""
+
+    @pytest.fixture
+    def gatewayless(self, hass, api) -> LockUpdateCoordinator:
+        return _gatewayless(hass, api)
+
+    @pytest.fixture
+    def refresh_requests(self, monkeypatch):
+        """Stub a coordinator's async_request_refresh, returning the mock."""
+
+        def _stub(coordinator: LockUpdateCoordinator) -> AsyncMock:
+            requested = AsyncMock()
+            monkeypatch.setattr(coordinator, "async_request_refresh", requested)
+            return requested
+
+        return _stub
+
+    async def test_a_gatewayless_lock_starts_unreachable(self, gatewayless):
+        assert gatewayless.cloud_connectable is False
+        assert gatewayless.connectable is False
+        assert gatewayless.update_interval is None
+
+    async def test_radio_range_is_enough_on_its_own(self, gatewayless):
+        gatewayless.ble = BleData(rssi=-60, connectable=True)
+
+        assert gatewayless.ble_reachable is True
+        assert gatewayless.connectable is True
+
+    async def test_a_passive_sighting_is_not_reachability(self, gatewayless):
+        """A passive-only scanner hears the lock but can't connect to it."""
+        gatewayless.ble = BleData(rssi=-60, connectable=False)
+
+        assert gatewayless.connectable is False
+
+    async def test_a_cloud_reachable_lock_does_not_need_the_radio(self, coordinator):
+        assert coordinator.ble_reachable is False
+        assert coordinator.connectable is True
+
+    async def test_coming_into_range_starts_the_poll(
+        self, hass, gatewayless, refresh_requests, mock_bluetooth, ble_advertisement
+    ):
+        requested = refresh_requests(gatewayless)
+        gatewayless.async_start_ble_tracking()
+        assert mock_bluetooth.advertisement is not None
+
+        mock_bluetooth.advertisement(ble_advertisement(), ADVERTISEMENT)
+        await hass.async_block_till_done()
+
+        assert gatewayless.connectable is True
+        assert gatewayless.update_interval == POLL_INTERVAL
+        requested.assert_awaited_once()
+
+    async def test_going_out_of_range_stops_the_poll(
+        self, hass, gatewayless, refresh_requests, mock_bluetooth, ble_advertisement
+    ):
+        refresh_requests(gatewayless)
+        gatewayless.async_start_ble_tracking()
+        assert mock_bluetooth.advertisement is not None
+        assert mock_bluetooth.unavailable is not None
+        mock_bluetooth.advertisement(ble_advertisement(), ADVERTISEMENT)
+
+        mock_bluetooth.unavailable(ble_advertisement())
+        await hass.async_block_till_done()
+
+        assert gatewayless.connectable is False
+        assert gatewayless.update_interval is None
+
+    async def test_only_the_edge_schedules_anything(
+        self, hass, gatewayless, refresh_requests, mock_bluetooth, ble_advertisement
+    ):
+        """Advertisements arrive every couple of seconds; polls must not."""
+        requested = refresh_requests(gatewayless)
+        gatewayless.async_start_ble_tracking()
+        assert mock_bluetooth.advertisement is not None
+
+        for _ in range(10):
+            mock_bluetooth.advertisement(ble_advertisement(), ADVERTISEMENT)
+        await hass.async_block_till_done()
+
+        requested.assert_awaited_once()
+
+    async def test_a_cloud_reachable_lock_has_its_poll_left_alone(
+        self, hass, coordinator, refresh_requests, mock_bluetooth, ble_advertisement
+    ):
+        requested = refresh_requests(coordinator)
+        coordinator.async_start_ble_tracking()
+        assert mock_bluetooth.advertisement is not None
+        assert mock_bluetooth.unavailable is not None
+        heard = ble_advertisement(address=coordinator.data.mac)
+
+        mock_bluetooth.advertisement(heard, ADVERTISEMENT)
+        mock_bluetooth.unavailable(heard)
+        await hass.async_block_till_done()
+
+        assert coordinator.update_interval == POLL_INTERVAL
+        requested.assert_not_awaited()
+
+    async def test_an_unreachable_lock_spends_no_api_call(
+        self, gatewayless, monkeypatch
+    ):
+        get_lock = AsyncMock()
+        monkeypatch.setattr(gatewayless.api, "get_lock", get_lock)
+
+        await gatewayless.async_refresh()
+
+        assert gatewayless.last_update_success is False
+        get_lock.assert_not_awaited()
+
+    async def test_diagnostics_show_both_halves(self, gatewayless):
+        gatewayless.ble = BleData(rssi=-60, connectable=True)
+
+        dumped = gatewayless.as_dict()
+
+        assert dumped["connectable"] is True
+        assert dumped["cloud_connectable"] is False
+        assert dumped["ble_reachable"] is True
+        assert dumped["ble_proven"] is False
+
+
+class TestCoordinatorBleProof:
+    """A read that worked vouches for the lock after its advertisements stop.
+
+    TTLock locks advertise in bursts minutes apart; without this a lock that
+    answers every poll would flap unavailable between bursts.
+    """
+
+    @pytest.fixture
+    def locked_locally(self, speaking_lock, aes_key):
+        speaking_lock.answer(Command.RESPONSE, STATUS_LOCKED, key=aes_key)
+        return speaking_lock
+
+    @pytest.fixture
+    async def read_locally(self, coordinator, mock_api_responses, locked_locally):
+        """The coordinator, having just read the lock over Bluetooth."""
+        mock_api_responses("default")
+        coordinator.ble = BleData(rssi=-60, connectable=True)
+        await coordinator.async_refresh()
+        assert coordinator.data.locked is True
+        assert locked_locally.gatt.connects == 1
+        return coordinator
+
+    async def test_a_read_that_worked_outlasts_the_advertisements(self, read_locally):
+        read_locally.ble = BleData()
+
+        assert read_locally.ble_proven is True
+        assert read_locally.ble_reachable is True
+
+    async def test_a_quiet_lock_that_answered_is_still_asked(
+        self, read_locally, locked_locally
+    ):
+        """The read path honours the proof too - else every poll falls to the cloud."""
+        read_locally.ble = BleData()
+
+        await read_locally.async_refresh()
+
+        assert locked_locally.gatt.connects == 2
+        assert read_locally.data.locked is True
+
+    async def test_the_proof_outlives_the_poll(self, read_locally):
+        """Shorter, and a healthy lock would flap while waiting for its next poll."""
+        later = dt_util.utcnow() + POLL_INTERVAL + timedelta(minutes=1)
+
+        with patch.object(dt_util, "utcnow", return_value=later):
+            assert read_locally.ble_proven is True
+
+    async def test_the_proof_expires(self, read_locally):
+        later = dt_util.utcnow() + 2 * POLL_INTERVAL + timedelta(minutes=1)
+
+        with patch.object(dt_util, "utcnow", return_value=later):
+            assert read_locally.ble_proven is False
+
+    async def test_a_read_that_failed_proves_nothing(
+        self, read_locally, locked_locally
+    ):
+        locked_locally.gatt.connect_error = BleakError("refused")
+
+        await read_locally.async_refresh()
+        read_locally.ble = BleData()
+
+        assert read_locally.data.locked is False  # the cloud answered
+        assert read_locally.ble_proven is False
+
+    async def test_a_local_read_ends_the_retry_cadence(
+        self, read_locally, locked_locally, monkeypatch
+    ):
+        _cloud_state_fails(monkeypatch)
+        locked_locally.gatt.connect_error = BleakError("refused")
+        await read_locally.async_refresh()
+        assert read_locally.last_update_success is True
+        assert read_locally.update_interval == RETRY_INTERVAL
+
+        locked_locally.gatt.connect_error = None
+        await read_locally.async_refresh()
+
+        assert read_locally.update_interval == POLL_INTERVAL
+
+    async def test_an_advertisement_does_not_slow_down_a_recovery(
+        self,
+        hass,
+        read_locally,
+        locked_locally,
+        mock_bluetooth,
+        ble_advertisement,
+        monkeypatch,
+    ):
+        """A lock still reachable stays on the retry cadence when it advertises."""
+        read_locally.async_start_ble_tracking()
+        assert mock_bluetooth.advertisement is not None
+        _cloud_state_fails(monkeypatch)
+        locked_locally.gatt.connect_error = BleakError("refused")
+        await read_locally.async_refresh()
+        assert read_locally.update_interval == RETRY_INTERVAL
+
+        mock_bluetooth.advertisement(
+            ble_advertisement(address=read_locally.data.mac), ADVERTISEMENT
+        )
+        await hass.async_block_till_done()
+
+        assert read_locally.update_interval == RETRY_INTERVAL

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,6 +7,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ttlock.api import TTLockAuthImplementation
 from custom_components.ttlock.const import (
+    CONF_BLUETOOTH_ENABLED,
     CONF_POLL_INTERVAL,
     CONF_REGION,
     CONF_SLOW_POLL_INTERVAL,
@@ -90,7 +91,11 @@ async def test_options_flow_saves_polling_cadence(hass: HomeAssistant):
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {CONF_POLL_INTERVAL: 45, CONF_SLOW_POLL_INTERVAL: 12},
+        {
+            CONF_POLL_INTERVAL: 45,
+            CONF_SLOW_POLL_INTERVAL: 12,
+            CONF_BLUETOOTH_ENABLED: True,
+        },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -100,3 +105,22 @@ async def test_options_flow_saves_polling_cadence(hass: HomeAssistant):
     assert isinstance(entry.options[CONF_POLL_INTERVAL], int)
     assert entry.options[CONF_SLOW_POLL_INTERVAL] == 12
     assert isinstance(entry.options[CONF_SLOW_POLL_INTERVAL], int)
+    assert entry.options[CONF_BLUETOOTH_ENABLED] is True
+
+
+async def test_options_flow_can_disable_bluetooth(hass: HomeAssistant):
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_POLL_INTERVAL: 30,
+            CONF_SLOW_POLL_INTERVAL: 6,
+            CONF_BLUETOOTH_ENABLED: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_BLUETOOTH_ENABLED] is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -411,6 +411,34 @@ class TestLockUpdateCoordinator:
             await verified.async_refresh()
 
             assert verified.last_update_success is False
+            assert verified.update_interval == verified._poll_interval
+
+        async def test_a_lock_that_stays_silent_is_not_retried_forever(
+            self, verified, cloud_state
+        ):
+            """Past the grace every poll is a failed GATT session; keep them rare."""
+            verified.ble = BleData(rssi=-60, connectable=True)
+            cloud_state(fails=True)
+            for _ in range(REVERIFY_GRACE):
+                await verified.async_refresh()
+
+            for _ in range(3):
+                await verified.async_refresh()
+                assert verified.last_update_success is False
+                assert verified.update_interval == verified._poll_interval
+
+        async def test_recovery_after_the_grace_ran_out(self, verified, cloud_state):
+            verified.ble = BleData(rssi=-60, connectable=True)
+            cloud_state(fails=True)
+            for _ in range(REVERIFY_GRACE + 1):
+                await verified.async_refresh()
+
+            cloud_state(fails=False)
+            await verified.async_refresh()
+
+            assert verified.last_update_success is True
+            assert verified._reverify_failures == 0
+            assert verified.update_interval == verified._poll_interval
 
         async def test_one_good_read_resets_the_grace(self, verified, cloud_state):
             verified.ble = BleData(rssi=-60, connectable=True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ttlock.api import RequestFailed, TTLockApi
+from custom_components.ttlock.ble import BleData
 from custom_components.ttlock.capture import LockTrafficCapture
 from custom_components.ttlock.const import (
     CONF_POLL_INTERVAL,
@@ -16,6 +17,8 @@ from custom_components.ttlock.const import (
     DOMAIN,
 )
 from custom_components.ttlock.coordinator import (
+    RETRY_INTERVAL,
+    REVERIFY_GRACE,
     GatewaysUpdateCoordinator,
     LockState,
     LockUpdateCoordinator,
@@ -350,6 +353,95 @@ class TestLockUpdateCoordinator:
             await coordinator.async_refresh()
 
             assert coordinator.last_update_success is False
+
+    class TestReverifyGrace:
+        """A lock the radio can hear rides out a couple of failed state reads.
+
+        One connection that didn't take says nothing about the bolt; a lock
+        nothing can hear still goes unavailable on the first failure.
+        """
+
+        @pytest.fixture
+        async def verified(self, coordinator, mock_api_responses):
+            """The coordinator, holding a state it has verified once."""
+            mock_api_responses("default")
+            await coordinator.async_refresh()
+            assert coordinator.data.locked is False
+            return coordinator
+
+        @pytest.fixture
+        def cloud_state(self, monkeypatch):
+            """Control whether lock/queryOpenState answers; returns the switch."""
+            failing = False
+
+            async def get_lock_state(self, lock_id):
+                if failing:
+                    raise RequestFailed("boom")
+                return WireLockState.model_validate(LOCK_STATE_LOCKED)
+
+            def _set(fails: bool) -> None:
+                nonlocal failing
+                failing = fails
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_lock_state",
+                get_lock_state,
+            )
+            return _set
+
+        async def test_an_audible_lock_rides_out_one_failed_read(
+            self, verified, cloud_state
+        ):
+            verified.ble = BleData(rssi=-60, connectable=True)
+            cloud_state(fails=True)
+
+            await verified.async_refresh()
+
+            assert verified.last_update_success is True
+            assert verified.data.locked is False
+            assert verified.update_interval == RETRY_INTERVAL
+
+        async def test_the_grace_runs_out(self, verified, cloud_state):
+            verified.ble = BleData(rssi=-60, connectable=True)
+            cloud_state(fails=True)
+
+            for _ in range(REVERIFY_GRACE):
+                await verified.async_refresh()
+                assert verified.last_update_success is True
+            await verified.async_refresh()
+
+            assert verified.last_update_success is False
+
+        async def test_one_good_read_resets_the_grace(self, verified, cloud_state):
+            verified.ble = BleData(rssi=-60, connectable=True)
+            cloud_state(fails=True)
+            for _ in range(REVERIFY_GRACE):
+                await verified.async_refresh()
+
+            cloud_state(fails=False)
+            await verified.async_refresh()
+            assert verified.update_interval == timedelta(minutes=30)
+
+            cloud_state(fails=True)
+            for _ in range(REVERIFY_GRACE):
+                await verified.async_refresh()
+                assert verified.last_update_success is True
+
+        async def test_a_silent_lock_gets_no_grace(self, verified, cloud_state):
+            cloud_state(fails=True)
+
+            await verified.async_refresh()
+
+            assert verified.last_update_success is False
+            assert verified.update_interval == timedelta(minutes=30)
+
+        async def test_a_passive_sighting_gets_no_grace(self, verified, cloud_state):
+            verified.ble = BleData(rssi=-60, connectable=False)
+            cloud_state(fails=True)
+
+            await verified.async_refresh()
+
+            assert verified.last_update_success is False
 
     class TestGatewayLinks:
         """gateway/listByLock results feed LockState.gateways/best_gateway,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -64,11 +64,15 @@ async def test_diagnostics_includes_connectable_and_health(
 
     locks_by_id = {lock["unique_id"]: lock for lock in diagnostics["locks"]}
     assert locks_by_id[f"{DOMAIN}-7252408"]["connectable"] is True
+    assert locks_by_id[f"{DOMAIN}-7252408"]["cloud_connectable"] is True
     assert locks_by_id[f"{DOMAIN}-7252408"]["last_update_success"] is True
     # non-connectable coordinators are never refreshed at all (update_interval=None,
     # excluded from the background detail fill), so last_update_success just sits at
     # its untouched default - `connectable` is the signal to look at for these.
     assert locks_by_id[f"{DOMAIN}-2"]["connectable"] is False
+    assert locks_by_id[f"{DOMAIN}-2"]["cloud_connectable"] is False
+    assert locks_by_id[f"{DOMAIN}-2"]["ble_reachable"] is False
+    assert locks_by_id[f"{DOMAIN}-2"]["ble_proven"] is False
 
 
 async def test_diagnostics_redacts_oauth_token(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -182,6 +182,47 @@ async def test_setup_with_non_connectable_lock(
     assert "1 lock(s) have no gateway or WiFi" in caplog.text
 
 
+async def test_setup_with_a_gatewayless_lock_in_bluetooth_range(
+    hass,
+    component_setup,
+    mock_api_responses,
+    mock_bluetooth,
+    ble_advertisement,
+    monkeypatch,
+    caplog,
+):
+    """A lock only the radio can reach is polled and available from the start."""
+    mock_api_responses("default")
+
+    async def mock_get_locks(*args, **kwargs):
+        return [
+            LockSummary(
+                lockId=2,
+                lockAlias="No Gateway Lock",
+                lockMac="00:00:00:00:00:02",
+                hasGateway=0,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.ttlock.api.TTLockApi.get_locks", mock_get_locks
+    )
+    mock_bluetooth.seed = ble_advertisement(address="00:00:00:00:00:02")
+
+    await component_setup()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator = hass.data[DOMAIN][entry.entry_id][TT_LOCKS][0]
+    assert coordinator.cloud_connectable is False
+    assert coordinator.connectable is True
+    assert coordinator.update_interval is not None
+
+    entity = next(iter(coordinator.entities))
+    assert entity.available is True
+    assert "have no gateway or WiFi" not in caplog.text
+
+
 async def test_webhook_registered_and_unregistered_once_across_shared_entries(
     hass, mock_api_responses, multi_account_credential, new_mocked_entry
 ):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from custom_components.ttlock import async_remove_config_entry_device
 from custom_components.ttlock.capture import LockTrafficCapture
 from custom_components.ttlock.const import (
+    CONF_BLUETOOTH_ENABLED,
     CONF_POLL_INTERVAL,
     CONF_SLOW_POLL_INTERVAL,
     CONF_WEBHOOK_STATUS,
@@ -57,6 +58,25 @@ async def test_changing_options_reloads_with_new_interval(
     # reload rebuilt the coordinators with the new cadence
     coordinator = hass.data[DOMAIN][entry.entry_id][TT_LOCKS][0]
     assert coordinator.update_interval == timedelta(minutes=90)
+
+
+async def test_disabling_bluetooth_tears_down_tracking(
+    hass, component_setup, mock_api_responses, mock_bluetooth
+):
+    """Turning the option off reloads the entry, which releases the radio."""
+    mock_api_responses("default")
+    await component_setup()
+    assert mock_bluetooth.advertisement is not None
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_BLUETOOTH_ENABLED: False}
+    )
+    await hass.async_block_till_done()
+
+    assert mock_bluetooth.unsubscribed == ["advertisement", "unavailable"]
+    coordinator = hass.data[DOMAIN][entry.entry_id][TT_LOCKS][0]
+    assert coordinator.ble_enabled is False
 
 
 async def test_capture_is_shared_across_config_entries(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,7 +7,7 @@ refresh, which __init__.py runs in the background after platforms are set up
 confirms presence, not decided up front.
 """
 
-from custom_components.ttlock.const import DOMAIN
+from custom_components.ttlock.const import CONF_BLUETOOTH_ENABLED, DOMAIN, TT_LOCKS
 from custom_components.ttlock.models import GatewayLink, LockSummary
 from custom_components.ttlock.sensor import LockBleSignal
 from homeassistant.helpers import entity_registry as er
@@ -146,6 +146,24 @@ async def test_bluetooth_signal_entity_not_created_without_bluetooth(
     """A cloud-only host would only ever get an entity stuck on "unknown"."""
     mock_api_responses("default")
     coordinator = await component_setup()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{coordinator.unique_id}-lockblesignal"
+    )
+    assert entity_id is None
+
+
+async def test_bluetooth_signal_entity_not_created_when_bluetooth_is_disabled(
+    hass, multi_account_credential, new_mocked_entry, mock_api_responses, mock_bluetooth
+):
+    mock_api_responses("default")
+    await multi_account_credential(hass)
+    entry = new_mocked_entry(options={CONF_BLUETOOTH_ENABLED: False})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    coordinator = hass.data[DOMAIN][entry.entry_id][TT_LOCKS][0]
 
     registry = er.async_get(hass)
     entity_id = registry.async_get_entity_id(


### PR DESCRIPTION
Third BLE slice from discussion #325, on top of #332. This is M5 from the proposal: a lock with no gateway or WiFi stops being unavailable for good.

## What

`connectable` used to be decided once at discovery from the cloud's view and never revisited, so a lock the radio could read every time it was asked still sat unavailable with no polling. It now means *anything can reach the lock*:

- **Cloud half** (`cloud_connectable`): unchanged, decided once from `hasGateway`/WiFi.
- **Radio half** (`ble_reachable`): the lock is advertising in range and connectable, **or** a local read succeeded within the last two poll intervals (`ble_proven`). TTLock locks advertise in bursts minutes apart, so a completed read is better evidence than the age of the last packet; without it the entity flapped in every gap between bursts.

Polling follows the flip: coming into range starts the poll and requests a refresh, leaving range stops it, and advertisements themselves never schedule anything. A lock the radio can still hear rides out `REVERIFY_GRACE = 2` failed state reads at a one-minute retry cadence before going unavailable; a lock nothing can hear fails on the first read, as before.

- `coordinator.py`: `cloud_connectable`, `ble_reachable`, `ble_proven`, `connectable` as a property; `_async_reconcile_polling`, `_async_note_verified`, `_async_tolerate_failed_verification`; `async_read_state_ble` gated on `ble_reachable` and recording its proof. Diagnostics gain the three new booleans.
- `__init__.py`: the "unavailable" warning reworded to cover Bluetooth.
- `CONTEXT.md`: *Connectable* redefined.
- Tests: reachability, polling edges, proof lifetime and expiry, retry cadence, grace window, a gatewayless-in-range setup, diagnostics keys.

## Deliberately not here

- No local refresh timer; a gatewayless lock is still refreshed on the normal poll interval. That's the next slice.
- No cloud write-back and no lock/unlock; see #325 for why the write half is closed.

## Verified

`script/check` clean, 442 passed. On a KT170 with the gateway unplugged (`hasGateway: 0`) the entity stays available across the radio's silent gaps and follows manual turns on the next poll, with no reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
