### PR TITLE
Link lock device to gateway via via_device_id (fixes #335)

### DIFF
--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -535,9 +535,21 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         in sync with later successful refreshes.
         """
         if self.last_update_success and self.config_entry is not None:
-            dr.async_get(self.hass).async_get_or_create(
-                config_entry_id=self.config_entry.entry_id, **self.device_info
+            registry = dr.async_get(self.hass)
+            info = self.device_info
+            # Resolve the gateway link ourselves and set via_device_id rather
+            # than passing the identifier tuple as `via_device` to
+            # async_get_or_create - that parameter is deprecated and removed in
+            # HA 2027.8.0. If the gateway device isn't registered yet, leave the
+            # link untouched, mirroring async_get_or_create's own behaviour.
+            via_device = info.pop("via_device", None)
+            device = registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id, **info
             )
+            if via_device is not None:
+                gateway = registry.async_get_device(identifiers={via_device})
+                if gateway is not None:
+                    registry.async_update_device(device.id, via_device_id=gateway.id)
 
     @callback
     def _process_webhook_data(self, event: WebhookEvent):

--- a/custom_components/ttlock/coordinator.py
+++ b/custom_components/ttlock/coordinator.py
@@ -537,11 +537,7 @@ class LockUpdateCoordinator(DataUpdateCoordinator[LockState]):
         if self.last_update_success and self.config_entry is not None:
             registry = dr.async_get(self.hass)
             info = self.device_info
-            # Resolve the gateway link ourselves and set via_device_id rather
-            # than passing the identifier tuple as `via_device` to
-            # async_get_or_create - that parameter is deprecated and removed in
-            # HA 2027.8.0. If the gateway device isn't registered yet, leave the
-            # link untouched, mirroring async_get_or_create's own behaviour.
+            # Resolve the gateway link ourselves and set via_device_id
             via_device = info.pop("via_device", None)
             device = registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id, **info

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -30,6 +30,7 @@ from custom_components.ttlock.models import (
     WebhookEvent,
 )
 from custom_components.ttlock.store import LockStateStore
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -393,6 +394,84 @@ class TestLockUpdateCoordinator:
                 DOMAIN,
                 "00:00:00:00:00:02",
             )
+
+        async def test_refresh_links_lock_device_to_gateway_by_id(
+            self,
+            hass,
+            coordinator: LockUpdateCoordinator,
+            mock_api_responses,
+            monkeypatch,
+        ):
+            """_async_refresh_finished links the lock's device to the gateway
+            via via_device_id (resolved ourselves), not the deprecated
+            `via_device` identifier tuple removed in HA 2027.8.0."""
+            mock_api_responses("default")
+
+            assert coordinator.config_entry is not None
+            registry = dr.async_get(hass)
+            gateway = registry.async_get_or_create(
+                config_entry_id=coordinator.config_entry.entry_id,
+                identifiers={(DOMAIN, "00:00:00:00:00:02")},
+                name="Strong",
+            )
+
+            async def mock_get_gateways_for_lock(*args, **kwargs):
+                return [
+                    GatewayLink(
+                        gatewayId=2,
+                        gatewayName="Strong",
+                        gatewayMac="00:00:00:00:00:02",
+                        rssi=-60,
+                    ),
+                ]
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_gateways_for_lock",
+                mock_get_gateways_for_lock,
+            )
+
+            await coordinator.async_refresh()
+
+            lock_device = registry.async_get_device(
+                identifiers={(DOMAIN, coordinator.data.mac)}
+            )
+            assert lock_device is not None
+            assert lock_device.via_device_id == gateway.id
+
+        async def test_refresh_tolerates_unregistered_gateway(
+            self,
+            hass,
+            coordinator: LockUpdateCoordinator,
+            mock_api_responses,
+            monkeypatch,
+        ):
+            """If the best gateway isn't in the device registry yet, the lock
+            device is still created, just without a via_device link."""
+            mock_api_responses("default")
+
+            async def mock_get_gateways_for_lock(*args, **kwargs):
+                return [
+                    GatewayLink(
+                        gatewayId=2,
+                        gatewayName="Strong",
+                        gatewayMac="00:00:00:00:00:02",
+                        rssi=-60,
+                    ),
+                ]
+
+            monkeypatch.setattr(
+                "custom_components.ttlock.api.TTLockApi.get_gateways_for_lock",
+                mock_get_gateways_for_lock,
+            )
+
+            await coordinator.async_refresh()
+
+            registry = dr.async_get(hass)
+            lock_device = registry.async_get_device(
+                identifiers={(DOMAIN, coordinator.data.mac)}
+            )
+            assert lock_device is not None
+            assert lock_device.via_device_id is None
 
         async def test_no_gateways_in_range_omits_via_device(
             self,


### PR DESCRIPTION
## Summary

Fixes #335 — the `via_device` deprecation warning logged on startup:

> Detected that custom integration 'ttlock' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead … This will stop working in Home Assistant 2027.8.0.

The culprit is `_async_refresh_finished` in `coordinator.py`, which splatted `**self.device_info` into `async_get_or_create`, passing the `(DOMAIN, mac)` identifier tuple as the deprecated `via_device` parameter. (The report guessed `device_info` itself; that path — `DeviceInfo.via_device` consumed by the entity platform — is *not* deprecated and is unchanged here.)

## Fix

Pop `via_device` off the kwargs, create/update the device without it, then resolve the gateway device ourselves and set the link through `async_update_device(..., via_device_id=gateway.id)`. If the gateway isn't registered yet, the link is left untouched — mirroring `async_get_or_create`'s own tolerance.

**Cross-version safety:** the pinned HA (2025.12.4) doesn't accept `via_device_id` on `async_get_or_create` (only later HA does), but `async_update_device` has accepted it throughout — so this works on both current and post-2027.8 HA.

## Tests

Two new tests under `TestGatewayLinks`:
- the lock device ends up with `via_device_id` pointing at the registered gateway device
- an unregistered gateway leaves `via_device_id` as `None` without failing

`script/check` passes (lint, type-check, 421 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)